### PR TITLE
Update integration test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ make -j unit
 make -j test
 ```
 
+#### To run one integration test:
+```text
+TEST_PATTERN=<test-function-or-file> make -j test
+```
+e.g.,
+```text
+TEST_PATTERN=test_sanity make -j test
+TEST_PATTERN=test_rdb.py make -j test
+```
+
 ## Load the Module
 To test the module with a Valkey, you can load the module using any of the following ways:
 
@@ -84,3 +94,4 @@ JSON.STRLEN
 JSON.TOGGLE
 JSON.TYPE
 ```
+

--- a/tst/integration/run.sh
+++ b/tst/integration/run.sh
@@ -8,12 +8,18 @@ pkill -9 -f "valkey-server.*:" || true
 pkill -9 -f Valgrind || true
 pkill -9 -f "valkey-benchmark" || true
 
+# If environment variable SERVER_VERSION is not set, default to "unstable"
+if [ -z "$SERVER_VERSION" ]; then
+    echo "WARNING: SERVER_VERSION environment variable is not set. Defaulting to \"unstable\"."
+    export SERVER_VERSION="unstable"
+fi
+
 # cd to the current directory of the script
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "${DIR}"
 
 export MODULE_PATH=$2/build/src/libjson.so 
-echo "Running integration tests against Valkey version: $SERVER_VERSION"
+echo "Running integration tests against Valkey version $SERVER_VERSION"
 
 if [[ ! -z "${TEST_PATTERN}" ]] ; then
     export TEST_PATTERN="-k ${TEST_PATTERN}"
@@ -32,3 +38,4 @@ else
     echo "Unknown target: $1"
     exit 1
 fi
+


### PR DESCRIPTION
Enhance the integration test script to check if environment variable SERVER_VERSION is set. If not, default to "unstable". Also update the README for how to run one integration test.

Details:

1. Running the integration test using "make test" failed:
```
Running integration tests against Valkey version: 
.build/binaries//valkey-server missing
make[3]: *** [CMakeFiles/test] Error 1
make[2]: *** [CMakeFiles/test.dir/all] Error 2
make[1]: *** [CMakeFiles/test.dir/rule] Error 2
make: *** [test] Error 2
```
2. The root cause is that environment variable SERVER_VERSION is missing.
3. Fixed by checking if environment variable SERVER_VERSION is set. If not, default to "unstable".