### PR TITLE
Build with valkey 8.0 (#36)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        server_version: ['unstable', '8.0.0']
+        server_version: ['unstable', '8.0']
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - name: Set the server version for python integration tests

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# ValkeyJSON
+# Valkey JSON
 
-ValkeyJSON is a C++ Valkey-Module that provides native JSON (JavaScript Object Notation) support for Valkey. The implementation complies with RFC7159 and ECMA-404 JSON data interchange standards. Users can natively store, query, and modify JSON data structures using the JSONPath query language. The query expressions support advanced capabilities including wildcard selections, filter expressions, array slices, union operations, and recursive searches.
+Valkey-json is a C++ Valkey-Module that provides native JSON (JavaScript Object Notation) support for Valkey. The implementation complies with RFC7159 and ECMA-404 JSON data interchange standards. Users can natively store, query, and modify JSON data structures using the JSONPath query language. The query expressions support advanced capabilities including wildcard selections, filter expressions, array slices, union operations, and recursive searches.
 
-ValkeyJSON leverages [RapidJSON](https://rapidjson.org/), a high-performance JSON parser and generator for C++, chosen for its small footprint and exceptional performance and memory efficiency. As a header-only library with no external dependencies, RapidJSON provides robust Unicode support while maintaining a compact memory profile of just 16 bytes per JSON value on most 32/64-bit machines.
+Valkey-json leverages [RapidJSON](https://rapidjson.org/), a high-performance JSON parser and generator for C++, chosen for its small footprint and exceptional performance and memory efficiency. As a header-only library with no external dependencies, RapidJSON provides robust Unicode support while maintaining a compact memory profile of just 16 bytes per JSON value on most 32/64-bit machines.
 
 ## Building and Testing
 
@@ -14,8 +14,8 @@ ValkeyJSON leverages [RapidJSON](https://rapidjson.org/), a high-performance JSO
 
 The default valkey version is "unstable". To override it, do:
 ```text
-# Build valkey-server (8.0.0) and run integration tests
-SERVER_VERSION=8.0.0 ./build.sh
+# Build valkey-server (8.0) and run integration tests
+SERVER_VERSION=8.0 ./build.sh
 ```
 
 Custom compiler flags can be passed to the build script via environment variable CFLAGS. For example:
@@ -35,7 +35,7 @@ The default valkey version is "unstable". To override it, do:
 ```text
 mdkir build
 cd build
-cmake .. -DVALKEY_VERSION=8.0.0
+cmake .. -DVALKEY_VERSION=8.0
 make
 ```
 


### PR DESCRIPTION
Build with valkey 8.0 instead of 8.0.0 so that we are building from the tip of valkey 8.0 branch.