### PR TITLE
Resolved issues when using GCC >= 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build-ubuntu-latest:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/src/json/dom.cc
+++ b/src/json/dom.cc
@@ -1416,13 +1416,8 @@ STATIC JValue readLegacyDoubleAsJValue(ValkeyModuleIO *rdb) {
     double d = ValkeyModule_LoadDouble(rdb);
     char str[BUF_SIZE_DOUBLE_JSON];
     size_t str_len = jsonutil_double_to_string(d, str, sizeof(str));
-    if (str) {
         JValue v(str, str_len, allocator, false, /* isdouble */ true);
         return v;
-    } else {
-        ValkeyModule_LogIOError(rdb, "error", "Unable to read legacy double");
-        return JValue();
-    }
 }
 
 /*

--- a/src/json/memory.h
+++ b/src/json/memory.h
@@ -98,7 +98,6 @@ namespace jsn
 template <typename T> class stl_allocator {
     public:
         using value_type = T;
-
         stl_allocator() = default;
         stl_allocator(const stl_allocator<T>&) noexcept = default;
         stl_allocator(stl_allocator<T>&&) noexcept = default;

--- a/src/json/memory.h
+++ b/src/json/memory.h
@@ -95,17 +95,40 @@ namespace jsn
 //
 // Our custom allocator
 //
-template <typename T> class stl_allocator : public std::allocator<T> {
- public:
-    typedef T value_type;
-    stl_allocator() = default;
-    stl_allocator(std::allocator<T>&) {}
-    stl_allocator(std::allocator<T>&&) {}
-    template <class U> constexpr stl_allocator(const stl_allocator<U>&) noexcept {}
+template <typename T> class stl_allocator {
+    public:
+        using value_type = T;
 
-    T *allocate(std::size_t n) { return static_cast<T *>(memory_alloc(n*sizeof(T))); }
-    void deallocate(T *p, std::size_t n) { (void)n; memory_free(p); }
+        stl_allocator() = default;
+        stl_allocator(const stl_allocator<T>&) noexcept = default;
+        stl_allocator(stl_allocator<T>&&) noexcept = default;
+        template <class U>
+        constexpr stl_allocator(const stl_allocator<U>&) noexcept {}
+
+        T* allocate(std::size_t n) {
+            return static_cast<T*>(memory_alloc(n * sizeof(T)));
+        }
+
+        void deallocate(T* p, std::size_t n) {
+            (void)n; 
+            memory_free(p);
+        }
+    
+    private:
+        static void* memory_alloc(std::size_t size) {
+            return std::malloc(size);
+        }
+
+        static void memory_free(void* p) {
+            std::free(p);
+        }
 };
+
+template <typename T, typename U>
+bool operator==(const stl_allocator<T>&, const stl_allocator<U>&) { return true; }
+
+template <typename T, typename U>
+bool operator!=(const stl_allocator<T>&, const stl_allocator<U>&) { return false; }
 
 template<class Elm> using vector = std::vector<Elm, stl_allocator<Elm>>;
 

--- a/src/rapidjson/document.h
+++ b/src/rapidjson/document.h
@@ -2512,7 +2512,7 @@ private:
         DoReserveMembersVec(count, allocator);
         const typename GenericValue<Encoding,SourceAllocator>::Member* rm = rhs.GetMembersPointerVec();
         for (SizeType i = 0; i < count; i++) {
-            KeyTable_Handle name = std::move(keyTable->clone(rm[i].name));
+            KeyTable_Handle name = keyTable->clone(rm[i].name);
             GenericValue value(rm[i].value, allocator, copyConstStrings);
             DoAddMember(name, value, allocator);
         }


### PR DESCRIPTION
This PR implements a standards-compliant custom allocator for ValkeyJSON that resolves compatibility issues with GCC 13. Additionally I fixed compiler errors and warnings that are related to standards enforced in GCC 13.

Resolves #17 