### PR TITLE
Decoupling JSON python tests from Bloom. Now using valkey-test-framework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,19 +98,19 @@ add_custom_command(TARGET valkey
     COMMENT "Copied valkeymodule.h and valkey-server to destination directories"
 )
 
-# Define valkey-bloom branch
-set(VALKEY_BLOOM_BRANCH "unstable" CACHE STRING "Valkey-bloom branch to use")
+# Define valkey-test-framework branch
+set(VALKEY_TEST_FRAMEWORK_BRANCH "unstable" CACHE STRING "Valkey-test-framework branch to use")
 
-# Set the download directory for Valkey-bloom
-set(VALKEY_BLOOM_DOWNLOAD_DIR "${CMAKE_CURRENT_BINARY_DIR}/_deps/valkey-bloom-src")
+# Set the download directory for Valkey-test-framework
+set(VALKEY_TEST_FRAMEWORK_DOWNLOAD_DIR "${CMAKE_CURRENT_BINARY_DIR}/_deps/valkey-test-framework-src")
 
-# Download valkey-bloom
+# Download valkey-test-framework
 ExternalProject_Add(
-    valkey-bloom
-    GIT_REPOSITORY https://github.com/valkey-io/valkey-bloom.git
-    GIT_TAG ${VALKEY_BLOOM_BRANCH}
+    valkey-test-framework
+    GIT_REPOSITORY https://github.com/valkey-io/valkey-test-framework.git
+    GIT_TAG ${VALKEY_TEST_FRAMEWORK_BRANCH}
     GIT_SHALLOW TRUE
-    PREFIX "${VALKEY_BLOOM_DOWNLOAD_DIR}"
+    PREFIX "${VALKEY_TEST_FRAMEWORK_DOWNLOAD_DIR}"
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND ""
@@ -118,12 +118,12 @@ ExternalProject_Add(
 
 # Step to copy pytest files
 ExternalProject_Add_Step(
-    valkey-bloom
+    valkey-test-framework
     copy_pytest_files
     COMMENT "Copying pytest files to tst/integration directory"
     DEPENDEES build
     COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_SOURCE_DIR}/tst/integration
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${VALKEY_BLOOM_DOWNLOAD_DIR}/src/valkey-bloom/tests/valkeytests ${CMAKE_CURRENT_SOURCE_DIR}/tst/integration/valkeytests
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${VALKEY_TEST_FRAMEWORK_DOWNLOAD_DIR}/src/valkey-test-framework/src ${CMAKE_CURRENT_SOURCE_DIR}/tst/integration/valkeytests
 )
 
 # Enable instrumentation options if requested

--- a/tst/integration/json_test_case.py
+++ b/tst/integration/json_test_case.py
@@ -13,10 +13,10 @@ class SimpleTestCase(ValkeyTestCase):
     '''
     Simple test case, single server without loading JSON module.
     '''
-
-    def setup(self):
-        super(SimpleTestCase, self).setup()
-        self.client = self.server.get_new_client()
+    @pytest.fixture(autouse=True)
+    def setup_test(self, setup):
+        server_path = f"{os.path.dirname(os.path.realpath(__file__))}/.build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
+        self.server, self.client = self.create_server(testdir = self.testdir,  server_path=server_path)
 
     def teardown(self):
         if self.is_connected():
@@ -37,14 +37,6 @@ class JsonTestCase(SimpleTestCase):
     Base class for JSON test, single server with JSON module loaded.
     '''
 
-    def get_custom_args(self):
-        self.set_server_version(os.environ['SERVER_VERSION'])
-        return {
-            'loadmodule': os.getenv('MODULE_PATH'),
-            "enable-debug-command": "local",
-            'enable-protected-configs': 'yes'
-        }
-
     def verify_error_response(self, client, cmd, expected_err_reply):
         try:
             client.execute_command(cmd)
@@ -53,8 +45,12 @@ class JsonTestCase(SimpleTestCase):
             assert_error_msg = f"Actual error message: '{str(e)}' is different from expected error message '{expected_err_reply}'"
             assert str(e) == expected_err_reply, assert_error_msg
 
-    def setup(self):
-        super(JsonTestCase, self).setup()
+    @pytest.fixture(autouse=True)
+    def setup_test(self, setup):
+        server_path = f"{os.path.dirname(os.path.realpath(__file__))}/.build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
+        args = {'loadmodule': os.getenv('MODULE_PATH'), "enable-debug-command": "local", 'enable-protected-configs': 'yes'}
+        self.server, self.client = self.create_server(testdir = self.testdir,  server_path=server_path, args=args)
+
         self.error_class = ErrorStringTester
 
     def teardown(self):

--- a/tst/integration/test_json_basic.py
+++ b/tst/integration/test_json_basic.py
@@ -12,6 +12,7 @@ import struct
 import json
 from math import isclose, isnan, isinf, frexp
 from json_test_case import JsonTestCase
+from error_handlers import ErrorStringTester
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -163,8 +164,13 @@ class TestJsonBasic(JsonTestCase):
         client.execute_command(
             'SET', str_key, '{"firstName":"John","lastName":"Smith"}')
 
-    def setup(self):
-        super(TestJsonBasic, self).setup()
+    @pytest.fixture(autouse=True)
+    def setup_test(self, setup):
+        server_path = f"{os.path.dirname(os.path.realpath(__file__))}/.build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
+        args = {'loadmodule': os.getenv('MODULE_PATH'), "enable-debug-command": "local", 'enable-protected-configs': 'yes'}
+        self.server, self.client = self.create_server(testdir = self.testdir,  server_path=server_path, args=args)
+
+        self.error_class = ErrorStringTester
         self.setup_data()
 
     def test_sanity(self):
@@ -3212,10 +3218,10 @@ class TestJsonBasic(JsonTestCase):
 
     def test_json_digest(self):
         client = self.server.get_new_client()
-        orig_digest = client.debug_digest()
+        orig_digest = client.execute_command('DEBUG', 'DIGEST')
         assert orig_digest != 0
         client.execute_command("flushall")
-        new_digest = client.debug_digest()
+        new_digest = client.execute_command('DEBUG', 'DIGEST')
         assert int(new_digest) == 0
 
     def test_big_dup(self):

--- a/tst/integration/test_rdb.py
+++ b/tst/integration/test_rdb.py
@@ -2,6 +2,8 @@ from utils_json import DEFAULT_MAX_PATH_LIMIT, DEFAULT_STORE_PATH
 from json_test_case import JsonTestCase
 from valkeytests.conftest import resource_port_tracker
 import logging, os, pathlib
+import pytest
+from error_handlers import ErrorStringTester
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -22,8 +24,13 @@ class TestRdb(JsonTestCase):
         assert b'OK' == client.execute_command(
             'JSON.SET', 'store', '.', self.data_store)
 
-    def setup(self):
-        super(TestRdb, self).setup()
+    @pytest.fixture(autouse=True)
+    def setup_test(self):
+        server_path = f"{os.path.dirname(os.path.realpath(__file__))}/.build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
+        args = {'loadmodule': os.getenv('MODULE_PATH'), "enable-debug-command": "local", 'enable-protected-configs': 'yes'}
+        self.server, self.client = self.create_server(testdir = self.testdir,  server_path=server_path, args=args)
+
+        self.error_class = ErrorStringTester
         self.setup_data()
 
     def test_rdb_saverestore(self):


### PR DESCRIPTION
Removed all mentions of bloom where we were pulling the test framework in the build script. Now we are pulling from valkey-test-framework. Due to this there were some changes that needed to be made, debug_digest is no longer a method as that was just a wrapper on running debug digest. We also now explicitly create the servers and clients not in the testframework as this allows more control for the developers. 
This pr updated all the above to be compatible with the new test framework