### PR TITLE
Improve build script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,46 +3,72 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  build-ubuntu-latest:
+  release-build:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         server_version: ['unstable', '8.0', '8.1']
     steps:
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-    - name: Set the server version for python integration tests
-      run: echo "SERVER_VERSION=${{ matrix.server_version }}" >> $GITHUB_ENV
-    - name: Set up Python
-      uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 #v3.1.4
-      with:
-        python-version: '3.9'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-    - name: Build and Run tests. 
-      run: ./build.sh
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Set the server version
+        run: echo "SERVER_VERSION=${{ matrix.server_version }}" >> $GITHUB_ENV
+      - name: Build release
+        run: ./build.sh --release
 
-  build-asan-ubuntu-latest:
+  unit-tests:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         server_version: ['unstable', '8.0', '8.1']
     steps:
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-    - name: Set the server version for python integration tests
-      run: echo "SERVER_VERSION=${{ matrix.server_version }}" >> $GITHUB_ENV
-    - name: Set up Python
-      uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 #v3.1.4
-      with:
-        python-version: '3.9'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-    - name: Build and Run tests. 
-      run: |
-        export ASAN_BUILD=true
-        ./build.sh
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Set the server version
+        run: echo "SERVER_VERSION=${{ matrix.server_version }}" >> $GITHUB_ENV
+      - name: Run unit tests
+        run: ./build.sh --unit
+
+  integration-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        server_version: ['unstable', '8.0', '8.1']
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Set the server version
+        run: echo "SERVER_VERSION=${{ matrix.server_version }}" >> $GITHUB_ENV
+      - name: Set up Python
+        uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3.1.4
+        with:
+          python-version: '3.9'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run integration tests
+        run: ./build.sh --integration
+
+  asan-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        server_version: ['unstable', '8.0', '8.1']
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Set the server version
+        run: echo "SERVER_VERSION=${{ matrix.server_version }}" >> $GITHUB_ENV
+      - name: Set up Python
+        uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3.1.4
+        with:
+          python-version: '3.9'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run ASAN integration tests
+        run: |
+          export ASAN_BUILD=true
+          ./build.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  release-build:
+  build-release:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -14,7 +14,7 @@ jobs:
       - name: Set the server version
         run: echo "SERVER_VERSION=${{ matrix.server_version }}" >> $GITHUB_ENV
       - name: Build release
-        run: ./build.sh --release
+        run: ./build.sh
 
   unit-tests:
     runs-on: ubuntu-latest
@@ -71,4 +71,4 @@ jobs:
       - name: Run ASAN integration tests
         run: |
           export ASAN_BUILD=true
-          ./build.sh
+          ./build.sh --integration

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,15 @@ endif()
 # Set the name of the JSON shared library
 set(JSON_MODULE_LIB json)
 
-# Define the Valkey directories
+# Skip building Valkey when building in release or unit-test mode. Integration
+# tests require the full Valkey sources while release and unit modes only need
+# the `valkeymodule.h` header. When `RELEASE_BUILD` is enabled the build system
+# clones Valkey but does not compile it.
+option(RELEASE_BUILD "Clone Valkey only for valkeymodule.h" OFF)
+option(ENABLE_UNIT_TESTS "Enable unit tests" ON)
+option(ENABLE_INTEGRATION_TESTS "Enable integration tests" ON)
+
+# Define the Valkey directories used when building from source
 set(VALKEY_DOWNLOAD_DIR "${CMAKE_BINARY_DIR}/_deps/valkey-src")
 set(VALKEY_BIN_DIR "${CMAKE_BINARY_DIR}/_deps/valkey-src/src/valkey/src")
 
@@ -55,22 +63,30 @@ if(ENABLE_ASAN)
 endif()
 
 message("CFLAGS: ${CFLAGS}")
-
-if(ENABLE_ASAN)
-    message("Building Valkey engine with Address Sanitizer enabled")
-    set(BUILD_CMD make distclean && make -j SANITIZER=address)
+message("RELEASE_BUILD: ${RELEASE_BUILD}")
+message("ENABLE_UNIT_TESTS: ${ENABLE_UNIT_TESTS}")
+message("ENABLE_INTEGRATION_TESTS: ${ENABLE_INTEGRATION_TESTS}")
+# Determine Valkey build command depending on build type
+if((RELEASE_BUILD OR ENABLE_UNIT_TESTS) AND NOT ENABLE_INTEGRATION_TESTS)
+    set(VALKEY_BUILD_CMD ${CMAKE_COMMAND} -E echo "Skipping build step for release build")
 else()
-    set(BUILD_CMD make distclean && make -j)
+    if(ENABLE_ASAN)
+        message("Building Valkey engine with Address Sanitizer enabled")
+        set(VALKEY_BUILD_CMD make distclean && make -j SANITIZER=address)
+    else()
+        set(VALKEY_BUILD_CMD make distclean && make -j)
+    endif()
 endif()
 
-# Download and build Valkey with ASAN if enabled
+message("Valkey build command: ${VALKEY_BUILD_CMD}")
+message("CMAKE_CMD : ${CMAKE_COMMAND}")
 ExternalProject_Add(
     valkey
     GIT_REPOSITORY https://github.com/valkey-io/valkey.git
     GIT_TAG ${VALKEY_VERSION}
     PREFIX ${VALKEY_DOWNLOAD_DIR}
     CONFIGURE_COMMAND ""
-    BUILD_COMMAND ${BUILD_CMD}
+    BUILD_COMMAND ${VALKEY_BUILD_CMD}
     INSTALL_COMMAND ""
     BUILD_IN_SOURCE 1
 )
@@ -90,41 +106,42 @@ ExternalProject_Add_Step(
     ALWAYS 1
 )
 
-# Copy header and binary after Valkey make
-add_custom_command(TARGET valkey
-    POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${VALKEY_BINARY_DEST}
-    COMMAND ${CMAKE_COMMAND} -E copy ${VALKEY_BIN_DIR}/valkey-server ${VALKEY_BINARY_DEST}/valkey-server
-    COMMENT "Copied valkeymodule.h and valkey-server to destination directories"
-)
+# Integration tests require the valkey-test-framework which is only needed when
+# building Valkey from source.
+if(ENABLE_INTEGRATION_TESTS)
+    # Copy the valkey-server binary after building
+    add_custom_command(TARGET valkey
+            POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${VALKEY_BINARY_DEST}
+            COMMAND ${CMAKE_COMMAND} -E copy ${VALKEY_BIN_DIR}/valkey-server ${VALKEY_BINARY_DEST}/valkey-server
+            COMMENT "Copied valkey-server to destination directory"
+        )
+    # Define valkey-test-framework commit id
+    set(VALKEY_TEST_FRAMEWORK_COMMIT "9fb28b74efd122324db00498a2fde6e5d281c90f" CACHE STRING "Valkey-test-framework commit to use")
 
-# Define valkey-test-framework commit id
-set(VALKEY_TEST_FRAMEWORK_COMMIT "9fb28b74efd122324db00498a2fde6e5d281c90f" CACHE STRING "Valkey-test-framework commit to use")
+    # Set the download directory for Valkey-test-framework
+    set(VALKEY_TEST_FRAMEWORK_DOWNLOAD_DIR "${CMAKE_CURRENT_BINARY_DIR}/_deps/valkey-test-framework-src")
 
-# Set the download directory for Valkey-test-framework
-set(VALKEY_TEST_FRAMEWORK_DOWNLOAD_DIR "${CMAKE_CURRENT_BINARY_DIR}/_deps/valkey-test-framework-src")
+    ExternalProject_Add(
+        valkey-test-framework
+        GIT_REPOSITORY https://github.com/valkey-io/valkey-test-framework.git
+        GIT_TAG ${VALKEY_TEST_FRAMEWORK_COMMIT}
+        GIT_SHALLOW FALSE
+        PREFIX "${VALKEY_TEST_FRAMEWORK_DOWNLOAD_DIR}"
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ""
+        INSTALL_COMMAND ""
+    )
 
-# Download valkey-test-framework
-ExternalProject_Add(
-    valkey-test-framework
-    GIT_REPOSITORY https://github.com/valkey-io/valkey-test-framework.git
-    GIT_TAG ${VALKEY_TEST_FRAMEWORK_COMMIT}
-    GIT_SHALLOW TRUE
-    PREFIX "${VALKEY_TEST_FRAMEWORK_DOWNLOAD_DIR}"
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND ""
-    INSTALL_COMMAND ""
-)
-
-# Step to copy pytest files
-ExternalProject_Add_Step(
-    valkey-test-framework
-    copy_pytest_files
-    COMMENT "Copying pytest files to tst/integration directory"
-    DEPENDEES build
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_SOURCE_DIR}/tst/integration
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${VALKEY_TEST_FRAMEWORK_DOWNLOAD_DIR}/src/valkey-test-framework/src ${CMAKE_CURRENT_SOURCE_DIR}/tst/integration/valkeytests
-)
+    ExternalProject_Add_Step(
+        valkey-test-framework
+        copy_pytest_files
+        COMMENT "Copying pytest files to tst/integration directory"
+        DEPENDEES build
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_SOURCE_DIR}/tst/integration
+        COMMAND ${CMAKE_COMMAND} -E copy_directory ${VALKEY_TEST_FRAMEWORK_DOWNLOAD_DIR}/src/valkey-test-framework/src ${CMAKE_CURRENT_SOURCE_DIR}/tst/integration/valkeytests
+    )
+endif()
 
 # Enable instrumentation options if requested
 if("$ENV{INSTRUMENT_V2PATH}" STREQUAL "yes")
@@ -181,14 +198,19 @@ FetchContent_MakeAvailable(rapidjson)
 
 add_subdirectory(src)
 
-add_subdirectory(tst)
+if(ENABLE_UNIT_TESTS OR ENABLE_INTEGRATION_TESTS)
+    add_subdirectory(tst)
+endif()
 
-add_custom_target(test
-    COMMENT "Run valkey-json integration tests"
-    USES_TERMINAL
-    COMMAND rm -rf ${CMAKE_BINARY_DIR}/tst/integration
-    COMMAND mkdir -p ${CMAKE_BINARY_DIR}/tst/integration
-    COMMAND cp -rp ${CMAKE_SOURCE_DIR}/tst/integration/. ${CMAKE_BINARY_DIR}/tst/integration/
-    COMMAND echo "[TARGET] begin integration tests"
-    COMMAND ${CMAKE_SOURCE_DIR}/tst/integration/run.sh "test" ${CMAKE_SOURCE_DIR} 
-    COMMAND echo "[TARGET] end integration tests")
+if(ENABLE_INTEGRATION_TESTS)
+    message("adding test target")
+    add_custom_target(test
+        COMMENT "Run valkey-json integration tests"
+        USES_TERMINAL
+        COMMAND rm -rf ${CMAKE_BINARY_DIR}/tst/integration
+        COMMAND mkdir -p ${CMAKE_BINARY_DIR}/tst/integration
+        COMMAND cp -rp ${CMAKE_SOURCE_DIR}/tst/integration/. ${CMAKE_BINARY_DIR}/tst/integration/
+        COMMAND echo "[TARGET] begin integration tests"
+        COMMAND ${CMAKE_SOURCE_DIR}/tst/integration/run.sh "test" ${CMAKE_SOURCE_DIR}
+        COMMAND echo "[TARGET] end integration tests")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 # Set the name of the JSON shared library
 set(JSON_MODULE_LIB json)
 
-option(RELEASE_BUILD "Build only valkey-json module" OFF)
+option(BUILD_RELEASE "Build only valkey-json module" OFF)
 option(ENABLE_UNIT_TESTS "Build the module and runs unit tests" ON)
 option(ENABLE_INTEGRATION_TESTS "Build the module and runs integration tests" ON)
 
@@ -59,7 +59,7 @@ if(ENABLE_ASAN)
 endif()
 
 # Determine Valkey build command depending on build type
-if((RELEASE_BUILD OR ENABLE_UNIT_TESTS) AND NOT ENABLE_INTEGRATION_TESTS)
+if((BUILD_RELEASE OR ENABLE_UNIT_TESTS) AND NOT ENABLE_INTEGRATION_TESTS)
     set(VALKEY_BUILD_CMD ${CMAKE_COMMAND} -E echo "Skipping build step for release build")
 else()
     if(ENABLE_ASAN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,13 +31,9 @@ endif()
 # Set the name of the JSON shared library
 set(JSON_MODULE_LIB json)
 
-# Skip building Valkey when building in release or unit-test mode. Integration
-# tests require the full Valkey sources while release and unit modes only need
-# the `valkeymodule.h` header. When `RELEASE_BUILD` is enabled the build system
-# clones Valkey but does not compile it.
-option(RELEASE_BUILD "Clone Valkey only for valkeymodule.h" OFF)
-option(ENABLE_UNIT_TESTS "Enable unit tests" ON)
-option(ENABLE_INTEGRATION_TESTS "Enable integration tests" ON)
+option(RELEASE_BUILD "Build only valkey-json module" OFF)
+option(ENABLE_UNIT_TESTS "Build the module and runs unit tests" ON)
+option(ENABLE_INTEGRATION_TESTS "Build the module and runs integration tests" ON)
 
 # Define the Valkey directories used when building from source
 set(VALKEY_DOWNLOAD_DIR "${CMAKE_BINARY_DIR}/_deps/valkey-src")
@@ -62,24 +58,17 @@ if(ENABLE_ASAN)
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${ASAN_FLAGS}")
 endif()
 
-message("CFLAGS: ${CFLAGS}")
-message("RELEASE_BUILD: ${RELEASE_BUILD}")
-message("ENABLE_UNIT_TESTS: ${ENABLE_UNIT_TESTS}")
-message("ENABLE_INTEGRATION_TESTS: ${ENABLE_INTEGRATION_TESTS}")
 # Determine Valkey build command depending on build type
 if((RELEASE_BUILD OR ENABLE_UNIT_TESTS) AND NOT ENABLE_INTEGRATION_TESTS)
     set(VALKEY_BUILD_CMD ${CMAKE_COMMAND} -E echo "Skipping build step for release build")
 else()
     if(ENABLE_ASAN)
-        message("Building Valkey engine with Address Sanitizer enabled")
         set(VALKEY_BUILD_CMD make distclean && make -j SANITIZER=address)
     else()
         set(VALKEY_BUILD_CMD make distclean && make -j)
     endif()
 endif()
 
-message("Valkey build command: ${VALKEY_BUILD_CMD}")
-message("CMAKE_CMD : ${CMAKE_COMMAND}")
 ExternalProject_Add(
     valkey
     GIT_REPOSITORY https://github.com/valkey-io/valkey.git

--- a/README.md
+++ b/README.md
@@ -4,17 +4,25 @@ Valkey-json is a Valkey module written in C++ that provides native JSON (JavaScr
 
 Valkey-json leverages [RapidJSON](https://rapidjson.org/), a high-performance JSON parser and generator for C++, chosen for its small footprint and exceptional performance and memory efficiency. As a header-only library with no external dependencies, RapidJSON provides robust Unicode support while maintaining a compact memory profile of just 16 bytes per JSON value on most 32/64-bit machines.
 
-## Building and Testing
+### Building and testing the module
+Valkey JSON  uses CMake for its build system. To simplify, a build script is provided. 
 
-#### To build the module and run tests
+To build and run all tests, use:
 ```text
-# Build valkey-server (unstable) and run integration tests
 ./build.sh
 ```
-
-The default valkey version is "unstable". To override it, do:
+To build only valkey-json module, use:
 ```text
-# Build valkey-server (8.0) and run integration tests
+./build.sh --release
+```
+To view the available arguments, use:
+```text
+./build.sh --help
+```
+
+The default valkey version is "unstable" for integration tests. To override it, do:
+```text
+# Build valkey-server (8.0)
 SERVER_VERSION=8.0 ./build.sh
 ```
 
@@ -22,55 +30,23 @@ Custom compiler flags can be passed to the build script via environment variable
 ```text
 CFLAGS="-O0 -Wno-unused-function" ./build.sh
 ```
-#### To build the module with ASAN and run tests
+
+To build the module with ASAN and run tests
 ```text
 export ASAN_BUILD=true
 ./build.sh
 ```
+`ASAN_BUILD` works with any of the build script options and enables memory leak
+checks in the integration tests.
 
-#### To build just the module
+To run single integration test:
 ```text
-mkdir build
-cd build
-cmake ..
-make
-```
-
-The default valkey version is "unstable". To override it, do:
-```text
-mkdir build
-cd build
-cmake .. -DVALKEY_VERSION=8.0
-make
-```
-
-Custom compiler flags can be passed to cmake via variable CFLAGS. For example:
-```text
-mkdir build
-cd build
-cmake .. -DCFLAGS="-O0 -Wno-unused-function"
-make
-```
-
-#### To run all unit tests:
-```text
-cd build
-make -j unit
-```
-
-#### To run all integration tests:
-```text
-make -j test
-```
-
-#### To run one integration test:
-```text
-TEST_PATTERN=<test-function-or-file> make -j test
+TEST_PATTERN=<test-function-or-file> ./build.sh --integration
 ```
 e.g.,
 ```text
-TEST_PATTERN=test_sanity make -j test
-TEST_PATTERN=test_rdb.py make -j test
+TEST_PATTERN=test_sanity ./build.sh --integration
+TEST_PATTERN=test_rdb.py ./build.sh --integration
 ```
 
 ## Cleaning

--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@ Valkey-json is a Valkey module written in C++ that provides native JSON (JavaScr
 Valkey-json leverages [RapidJSON](https://rapidjson.org/), a high-performance JSON parser and generator for C++, chosen for its small footprint and exceptional performance and memory efficiency. As a header-only library with no external dependencies, RapidJSON provides robust Unicode support while maintaining a compact memory profile of just 16 bytes per JSON value on most 32/64-bit machines.
 
 ### Building and testing the module
-Valkey JSON  uses CMake for its build system. To simplify, a build script is provided. 
+Valkey JSON uses CMake for its build system. To simplify, a build script is provided. 
 
-To build and run all tests, use:
+To build only valkey-json module, use:
 ```text
 ./build.sh
 ```
-To build only valkey-json module, use:
+To build and run unit tests, use:
 ```text
-./build.sh --release
+./build.sh --unit
 ```
 To view the available arguments, use:
 ```text
@@ -22,22 +22,14 @@ To view the available arguments, use:
 
 The default valkey version is "unstable" for integration tests. To override it, do:
 ```text
-# Build valkey-server (8.0)
-SERVER_VERSION=8.0 ./build.sh
+# Run integration tests with valkey-server (8.1)
+SERVER_VERSION=8.1 ./build.sh --integration
 ```
 
 Custom compiler flags can be passed to the build script via environment variable CFLAGS. For example:
 ```text
 CFLAGS="-O0 -Wno-unused-function" ./build.sh
 ```
-
-To build the module with ASAN and run tests
-```text
-export ASAN_BUILD=true
-./build.sh
-```
-`ASAN_BUILD` works with any of the build script options and enables memory leak
-checks in the integration tests.
 
 To run single integration test:
 ```text
@@ -49,14 +41,23 @@ TEST_PATTERN=test_sanity ./build.sh --integration
 TEST_PATTERN=test_rdb.py ./build.sh --integration
 ```
 
+`ASAN_BUILD` works with any of the build script options and enables memory leak
+checks in the integration tests.
+
+To build the module with ASAN and run tests
+```text
+export ASAN_BUILD=true
+./build.sh --integration
+```
+
 ## Cleaning
 ```text
 # Clean build artifacts
-./build.sh clean
+./build.sh --clean
 ```
 
 ## Load the Module
-To test the module with a Valkey, you can load the module using any of the following ways:
+To load the module on Valkey, use any of the following:
 
 #### Using valkey.conf:
 ```

--- a/build.sh
+++ b/build.sh
@@ -25,9 +25,9 @@ EOF
 
 SCRIPT_DIR=$(pwd)
 BUILD_DIR="$SCRIPT_DIR/build"
-RUN_UNIT=1
-RUN_INTEGRATION=1
-RELEASE_BUILD=0
+RUN_UNIT=0
+RUN_INTEGRATION=0
+BUILD_RELEASE=1
 CLEAN_BUILD=0
 
 ## Parse command line argument
@@ -36,14 +36,14 @@ do
     arg="$1"
     case $arg in
         --release)
-            RELEASE_BUILD=1
+            BUILD_RELEASE=1
             RUN_UNIT=0
             RUN_INTEGRATION=0
             ;;
         --unit)
             RUN_UNIT=1
             RUN_INTEGRATION=0
-            RELEASE_BUILD=0
+            BUILD_RELEASE=0
             ;;
         --integration)
             RUN_UNIT=0
@@ -101,13 +101,13 @@ else
     ENABLE_INTEGRATION_TESTS=OFF
 fi
 
-if [ $RELEASE_BUILD -eq 1 ]; then
-    ENABLE_RELEASE_BUILD=ON
+if [ $BUILD_RELEASE -eq 1 ]; then
+    ENABLE_BUILD_RELEASE=ON
 else
-    ENABLE_RELEASE_BUILD=OFF
+    ENABLE_BUILD_RELEASE=OFF
 fi
 
-CMAKE_FLAGS="$CMAKE_FLAGS -DENABLE_UNIT_TESTS=${ENABLE_UNIT_TESTS} -DENABLE_INTEGRATION_TESTS=${ENABLE_INTEGRATION_TESTS} -DRELEASE_BUILD=${ENABLE_RELEASE_BUILD}"
+CMAKE_FLAGS="$CMAKE_FLAGS -DENABLE_UNIT_TESTS=${ENABLE_UNIT_TESTS} -DENABLE_INTEGRATION_TESTS=${ENABLE_INTEGRATION_TESTS} -DBUILD_RELEASE=${ENABLE_BUILD_RELEASE}"
 
 if [ -z "${CFLAGS}" ]; then
     cmake .. -DVALKEY_VERSION=${SERVER_VERSION} ${CMAKE_FLAGS}
@@ -115,13 +115,13 @@ else
     cmake .. -DVALKEY_VERSION=${SERVER_VERSION} -DCFLAGS="${CFLAGS}" ${CMAKE_FLAGS}
 fi
 
-if [ $RELEASE_BUILD -eq 1 ] && [ $RUN_UNIT -eq 0 ] && [ $RUN_INTEGRATION -eq 0 ]; then
+if [ $BUILD_RELEASE -eq 1 ] && [ $RUN_UNIT -eq 0 ] && [ $RUN_INTEGRATION -eq 0 ]; then
     make -j
     echo "Release build completed"
     exit 0
 elif [ $RUN_UNIT -eq 1 ]; then
+    echo "Building valkey-json and running unit tests..."
     make -j unit
-    echo "Building valkey-json and running unit tests completed"
 fi
 
 if [ $RUN_INTEGRATION -eq 1 ]; then

--- a/build.sh
+++ b/build.sh
@@ -1,75 +1,145 @@
 #!/bin/bash
 
-# Script to build valkey-json module, build it and generate .so files, run unit and integration tests.
-
-# # Exit the script if any command fails
 set -e
 
-SCRIPT_DIR=$(pwd)
-echo "Script Directory: $SCRIPT_DIR"
+function print_usage() {
+cat<<EOF
+Usage: build.sh [--release] [--unit] [--integration] [--clean]
 
-if [ "$1" = "clean" ]; then
-  echo "Cleaning build artifacts"
-  rm -rf build/
-  echo "Clean completed."
-  exit 0
+    --help | -h               Print this help message and exit.
+    --release                 Builds the release configuration.
+    --unit                    Builds the unit tests configuration.
+    --integration             Builds the integration tests configuration.
+    --clean                   Cleans the build artifacts.
+
+Example usage:
+
+    # Build the release configuration,
+    ./build.sh --release
+
+    # Cleans the build artifacts,
+    ./build.sh --clean
+
+EOF
+}
+
+SCRIPT_DIR=$(pwd)
+BUILD_DIR="$SCRIPT_DIR/build"
+RUN_UNIT=1
+RUN_INTEGRATION=1
+RELEASE_BUILD=0
+CLEAN_BUILD=0
+
+## Parse command line argument
+while [[ $# -gt 0 ]]; 
+do
+    arg="$1"
+    case $arg in
+        --release)
+            RELEASE_BUILD=1
+            RUN_UNIT=0
+            RUN_INTEGRATION=0
+            ;;
+        --unit)
+            RUN_UNIT=1
+            RUN_INTEGRATION=0
+            RELEASE_BUILD=0
+            ;;
+        --integration)
+            RUN_UNIT=0
+            RUN_INTEGRATION=1
+            ;;
+        --clean)
+            CLEAN_BUILD=1
+            RUN_UNIT=0
+            RUN_INTEGRATION=0
+            ;;
+        --help|-h)
+            print_usage
+            exit 0
+            ;;
+        *)
+            print_usage
+            exit 1
+            ;;
+        esac
+    shift
+done
+
+if [ $CLEAN_BUILD -eq 1 ]; then
+    echo "Cleaning build artifacts..."
+    rm -rf "$BUILD_DIR" tst/integration/valkeytests tst/integration/.build src/include 
+    rm -rf tst/integration/assets tst/integration/test-data tst/integration/report.html
+    echo "Clean completed"
+    exit 0
 fi
 
-# If environment variable SERVER_VERSION is not set, default to "unstable"
 if [ -z "$SERVER_VERSION" ]; then
     echo "SERVER_VERSION environment variable is not set. Defaulting to \"unstable\"."
     export SERVER_VERSION="unstable"
 fi
 
-# Variables
-BUILD_DIR="$SCRIPT_DIR/build"
+mkdir -p "$BUILD_DIR"
+cd "$BUILD_DIR"
 
-# Build the Valkey JSON module using CMake
-echo "Building valkey-json..."
-if [ ! -d "$BUILD_DIR" ]; then
-    mkdir $BUILD_DIR
-fi
-cd $BUILD_DIR
-
-if [ ! -z "${ASAN_BUILD}" ]; then
+CMAKE_FLAGS=""
+if [ -n "${ASAN_BUILD}" ]; then
     CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DENABLE_ASAN=ON"
 else
-    CMAKE_FLAGS=""
+    CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Release"
 fi
+
+if [ $RUN_UNIT -eq 1 ]; then
+    ENABLE_UNIT_TESTS=ON
+else
+    ENABLE_UNIT_TESTS=OFF
+fi
+
+if [ $RUN_INTEGRATION -eq 1 ]; then
+    ENABLE_INTEGRATION_TESTS=ON
+else
+    ENABLE_INTEGRATION_TESTS=OFF
+fi
+
+if [ $RELEASE_BUILD -eq 1 ]; then
+    ENABLE_RELEASE_BUILD=ON
+else
+    ENABLE_RELEASE_BUILD=OFF
+fi
+
+CMAKE_FLAGS="$CMAKE_FLAGS -DENABLE_UNIT_TESTS=${ENABLE_UNIT_TESTS} -DENABLE_INTEGRATION_TESTS=${ENABLE_INTEGRATION_TESTS} -DRELEASE_BUILD=${ENABLE_RELEASE_BUILD}"
 
 if [ -z "${CFLAGS}" ]; then
-  cmake .. -DVALKEY_VERSION=${SERVER_VERSION} ${CMAKE_FLAGS}
+    cmake .. -DVALKEY_VERSION=${SERVER_VERSION} ${CMAKE_FLAGS}
 else
-  cmake .. -DVALKEY_VERSION=${SERVER_VERSION} -DCFLAGS=${CFLAGS} ${CMAKE_FLAGS}
-fi
-make
-
-# Running the Valkey JSON unit tests.
-echo "Running Unit Tests..."
-make -j unit
-
-cd $SCRIPT_DIR
-
-REQUIREMENTS_FILE="requirements.txt"
-
-# Check if pip is available
-if command -v pip > /dev/null 2>&1; then
-    echo "Using pip to install packages..."
-    pip install -r "$SCRIPT_DIR/$REQUIREMENTS_FILE"
-# Check if pip3 is available
-elif command -v pip3 > /dev/null 2>&1; then
-    echo "Using pip3 to install packages..."
-    pip3 install -r "$SCRIPT_DIR/$REQUIREMENTS_FILE"
-else
-    echo "Error: Neither pip nor pip3 is available. Please install Python package installer."
-    exit 1
+    cmake .. -DVALKEY_VERSION=${SERVER_VERSION} -DCFLAGS="${CFLAGS}" ${CMAKE_FLAGS}
 fi
 
-export MODULE_PATH="$SCRIPT_DIR/build/src/libjson.so"
+if [ $RELEASE_BUILD -eq 1 ] && [ $RUN_UNIT -eq 0 ] && [ $RUN_INTEGRATION -eq 0 ]; then
+    make -j
+    echo "Release build completed"
+    exit 0
+elif [ $RUN_UNIT -eq 1 ]; then
+    make -j unit
+    echo "Building valkey-json and running unit tests completed"
+fi
 
-# Running the Valkey JSON integration tests.
-echo "Running the integration tests..."
-cd $BUILD_DIR
-make -j test
+if [ $RUN_INTEGRATION -eq 1 ]; then
+    make -j
+    cd "$SCRIPT_DIR"
+    REQUIREMENTS_FILE="requirements.txt"
+    if command -v pip > /dev/null 2>&1; then
+        pip install -r "$SCRIPT_DIR/$REQUIREMENTS_FILE"
+    elif command -v pip3 > /dev/null 2>&1; then
+        pip3 install -r "$SCRIPT_DIR/$REQUIREMENTS_FILE"
+    else
+        echo "Error: Neither pip nor pip3 is available."
+        exit 1
+    fi
+    export MODULE_PATH="$BUILD_DIR/src/libjson.so"
+    cd "$BUILD_DIR"
+    echo "Running integration tests...${TEST_PATTERN}"
+    TEST_PATTERN=${TEST_PATTERN} make -j test
+fi
 
-echo "Build and Integration Tests succeeded"
+echo "Build script completed"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,8 +19,9 @@ target_include_directories(${OBJECT_TARGET}
 	# Need to make the source files public within CMake
 	# so that they are used when building the tests.
 	PUBLIC
-	${CMAKE_CURRENT_SOURCE_DIR}
-	${rapidjson_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${rapidjson_SOURCE_DIR}/include
 )
 
 # Add source files for the JSON module
@@ -38,3 +39,4 @@ target_sources(${OBJECT_TARGET}
 )
 
 add_library(${JSON_MODULE_LIB} SHARED $<TARGET_OBJECTS:${OBJECT_TARGET}>)
+add_dependencies(${OBJECT_TARGET} valkey)

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -3,17 +3,19 @@
 ##################################################
 message("tst/CMakeLists.txt")
 
-# Fetch GoogleTest.
-include(FetchContent)
+if(ENABLE_UNIT_TESTS)
+  # Fetch GoogleTest.
+  include(FetchContent)
 
-FetchContent_Declare(
-  googletest
-  GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG 58d77fa8070e8cec2dc1ed015d66b454c8d78850 # release-1.12.1
-  OVERRIDE_FIND_PACKAGE)
-FetchContent_MakeAvailable(googletest)
+  FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG 58d77fa8070e8cec2dc1ed015d66b454c8d78850 # release-1.12.1
+    OVERRIDE_FIND_PACKAGE)
+  FetchContent_MakeAvailable(googletest)
 
 
-include(GoogleTest)
+  include(GoogleTest)
 
-add_subdirectory(unit)
+  add_subdirectory(unit)
+endif()


### PR DESCRIPTION
Adds these options and build efficiently
```
Usage: build.sh [--release] [--unit] [--integration] [--clean]
    --help | -h               Print this help message and exit.
    --release                 Builds the release configuration.
    --unit                    Builds the unit tests configuration.
    --integration             Builds the integration tests configuration.
    --clean                   Cleans the build artifacts.
Example usage:
    # Build the release configuration,
    ./build.sh --release
    # Cleans the build artifacts,
    ./build.sh --clean
```

also updated the workflow to run all options.
fixes #62 

Refer the workflows that tests the script and also runs unit tests and integration tests for all versions
