### PR TITLE
Support building on Clang / Apple

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,27 @@ endif()
 project(ValkeyJSONModule VERSION 99.99.99 LANGUAGES C CXX) # Version is 99.99.99 for unstable branch
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-mismatched-tags -Wno-format")
+
+# Clang related adjustments
+set(COMPILER_IS_CLANG OFF)
 if (${CMAKE_C_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_C_COMPILER_ID} STREQUAL "AppleClang")
+    set(COMPILER_IS_CLANG ON)
+endif()
+
+if (COMPILER_IS_CLANG)
+    message(STATUS "Defining VALKEYMODULE_ATTR_COMMON => __attribute__((weak))")
     add_definitions(-DVALKEYMODULE_ATTR_COMMON=__attribute__\(\(weak\)\))
+endif()
+
+if(APPLE AND NOT COMPILER_IS_CLANG)
+    # Force clang compiler on macOS
+    find_program(CLANGPP "clang++")
+    find_program(CLANG "clang")
+    if(CLANG AND CLANGPP)
+          message(STATUS "Found ${CLANGPP}, ${CLANG}")
+          set(CMAKE_CXX_COMPILER ${CLANGPP})
+          set(CMAKE_C_COMPILER ${CLANG})
+    endif()
 endif()
 
 # ASAN build option

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.17)
 include(FetchContent)
 include(ExternalProject)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # Detect the system architecture
 EXECUTE_PROCESS(
     COMMAND uname -m
@@ -10,14 +12,24 @@ EXECUTE_PROCESS(
     OUTPUT_VARIABLE ARCHITECTURE
 )
 
-if("${ARCHITECTURE}" STREQUAL "x86_64" OR "${ARCHITECTURE}" STREQUAL "aarch64")
+if("${ARCHITECTURE}" STREQUAL "x86_64"
+   OR "${ARCHITECTURE}" STREQUAL "aarch64"
+   OR "${ARCHITECTURE}" STREQUAL "arm64")
     message("Building valkey-json for ${ARCHITECTURE}")
 else()
-    message(FATAL_ERROR "Unsupported architecture: ${ARCHITECTURE}. valkey-json is only supported on x86_64 and aarch64.")
+    message(
+        FATAL_ERROR
+            "Unsupported architecture: ${ARCHITECTURE}. valkey-json is only supported on x86_64, aarch64 and arm64"
+    )
 endif()
 
 # Project definition
 project(ValkeyJSONModule VERSION 99.99.99 LANGUAGES C CXX) # Version is 99.99.99 for unstable branch
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-mismatched-tags -Wno-format")
+if (${CMAKE_C_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_C_COMPILER_ID} STREQUAL "AppleClang")
+    add_definitions(-DVALKEYMODULE_ATTR_COMMON=__attribute__\(\(weak\)\))
+endif()
 
 # ASAN build option
 option(ENABLE_ASAN "Enable Address Sanitizer" OFF)

--- a/src/json/dom.cc
+++ b/src/json/dom.cc
@@ -174,7 +174,7 @@ JsonUtilCode dom_verify_value(ValkeyModuleCtx *ctx, JDocument *doc, const char *
     Selector selector;
     JsonUtilCode rc = selector.prepareSetValues(doc->GetJValue(), json_path);
     if (rc != JSONUTIL_SUCCESS) return rc;
-    
+
     JParser new_val;
     if (new_val.Parse(new_val_json, new_val_size).HasParseError()) {
         return new_val.GetParseErrorCode();
@@ -670,7 +670,7 @@ JsonUtilCode dom_object_keys(JDocument *doc, const char *path,
         jsn::vector<jsn::string> keys;
         if (v->IsObject()) {
             for (auto &m : v->GetObject()) {
-                keys.push_back(std::move(jsn::string(m.name.GetString(), m.name.GetStringLength())));
+                keys.push_back(jsn::string(m.name.GetString(), m.name.GetStringLength()));
             }
         }
         vec.push_back(keys);
@@ -1101,27 +1101,27 @@ JsonUtilCode dom_value_type(JDocument *doc, const char *path, jsn::vector<jsn::s
     for (auto &v : selector.getResultSet()) {
         switch (v.first->GetType()) {
             case rapidjson::kNullType:
-                vec.push_back(std::move(jsn::string(TYPE_NAMES[0])));
+                vec.push_back(jsn::string(TYPE_NAMES[0]));
                 break;
             case rapidjson::kTrueType:
             case rapidjson::kFalseType:
-                vec.push_back(std::move(jsn::string(TYPE_NAMES[1])));
+                vec.push_back(jsn::string(TYPE_NAMES[1]));
                 break;
             case rapidjson::kStringType:
-                vec.push_back(std::move(jsn::string(TYPE_NAMES[2])));
+                vec.push_back(jsn::string(TYPE_NAMES[2]));
                 break;
             case rapidjson::kNumberType: {
                 if (v.first->IsDouble())
-                    vec.push_back(std::move(jsn::string(TYPE_NAMES[3])));
+                    vec.push_back(jsn::string(TYPE_NAMES[3]));
                 else
-                    vec.push_back(std::move(jsn::string(TYPE_NAMES[4])));
+                    vec.push_back(jsn::string(TYPE_NAMES[4]));
                 break;
             }
             case rapidjson::kObjectType:
-                vec.push_back(std::move(jsn::string(TYPE_NAMES[5])));
+                vec.push_back(jsn::string(TYPE_NAMES[5]));
                 break;
             case rapidjson::kArrayType:
-                vec.push_back(std::move(jsn::string(TYPE_NAMES[6])));
+                vec.push_back(jsn::string(TYPE_NAMES[6]));
                 break;
             default:
                 ValkeyModule_Assert(false);
@@ -1513,7 +1513,7 @@ JValue rdbLoadJValue(load_params *params) {
             return array;
         }
         default:
-            ValkeyModule_LogIOError(params->rdb, "error", "Invalid metadata code %lx", code);
+            ValkeyModule_LogIOError(params->rdb, "error", "Invalid metadata code %llx", code);
             params->status = JSONUTIL_INVALID_RDB_FORMAT;
             return JValue();
     }

--- a/src/json/keytable.cc
+++ b/src/json/keytable.cc
@@ -302,7 +302,7 @@ struct KeyTable_Shard {
         if (duration == 0) duration = 1;
         uint64_t keys_per_second = (size / duration) * 1000;
         ValkeyModule_Log(nullptr, "notice",
-                        "Keytable Resize to %zu completed in %lu ms (%lu / sec)",
+                        "Keytable Resize to %zu completed in %llu ms (%llu / sec)",
                         capacity, duration, keys_per_second);
     }
 

--- a/src/json/keytable.h
+++ b/src/json/keytable.h
@@ -161,7 +161,7 @@ struct KeyTable_Layout {
 
  protected:
     KeyTable_Layout();               // Nobody gets to create one.
-    friend class KeyTable_Shard;     // Only class allowed to manipulate reference count
+    friend struct KeyTable_Shard;    // Only class allowed to manipulate reference count
     bool incrRefCount() const;       // true => saturated
     size_t decrRefCount() const;     // returns current count
     size_t original_hash;            // Remember original hash
@@ -233,7 +233,7 @@ struct KeyTable_Handle {
     }
 
  private:
-    friend class KeyTable;
+    friend struct KeyTable;
     friend struct KeyTable_Shard;
 
     KeyTable_Handle(KeyTable_Layout *ptr, size_t hashCode) : theHandle(ptr, hashCode) {}
@@ -369,7 +369,7 @@ struct KeyTable {
     size_t getNumShards() const { return numShards; }
 
  private:
-    friend class KeyTable_Shard;
+    friend struct KeyTable_Shard;
     size_t shardNumberFromHash(size_t hash);
     size_t hashcodeFromHash(size_t hash);
     KeyTable_Shard* shards;

--- a/src/json/stats.cc
+++ b/src/json/stats.cc
@@ -21,7 +21,7 @@ static pthread_key_t thread_local_mem_counter_key;
  * Use atomic integers due to possible multi-threading execution of rdb_load and
  * also the overhead of atomic operations are negligible.
  */
-typedef struct {
+typedef struct _JsonStats {
     std::atomic_ullong used_mem;  // global used memory counter
     std::atomic_ullong num_doc_keys;
     std::atomic_ullong max_depth_ever_seen;

--- a/src/json/stats.h
+++ b/src/json/stats.h
@@ -84,7 +84,7 @@ uint32_t jsonstats_find_bucket(size_t size);
  * We don't track the logical bytes themselves here as they are tracked by Skyhook Metering.
  * We are using size_t to match Valkey Module API for Data Metering.
  */
-typedef struct {
+typedef struct _LogicalStats {
     std::atomic_size_t boolean_count;  // 16 bytes
     std::atomic_size_t number_count;  // 16 bytes
     std::atomic_size_t sum_extra_numeric_chars;  // 1 byte per char

--- a/src/rapidjson/document.h
+++ b/src/rapidjson/document.h
@@ -1749,7 +1749,7 @@ public:
     /*! This function do not deallocate memory in the array, i.e. the capacity is unchanged.
         \note Linear time complexity.
     */
-    void Clear(Allocator &allocator) {
+    void Clear([[maybe_unused]] Allocator &allocator) {
         GenericValue* e = GetElementsPointer();
         for (GenericValue* v = e; v != e + data_.a.size; ++v)
             v->~GenericValue();
@@ -1859,7 +1859,7 @@ public:
     /*!
         \note Constant time complexity.
     */
-    GenericValue& PopBack(Allocator& allocator) {
+    GenericValue& PopBack([[maybe_unused]] Allocator& allocator) {
         RAPIDJSON_ASSERT(!Empty());
         GetElementsPointer()[--data_.a.size].~GenericValue();
         return *this;
@@ -2614,7 +2614,7 @@ private:
         //
         // Move the members from the copy into the new hashtable
         //
-        size_t object_member_count = 0;
+        [[maybe_unused]] size_t object_member_count = 0;
         size_t object_num_member_chars = 0;
         for (MemberIterator i = me.MemberBegin(); i != me.MemberEnd(); ++i) {
             object_member_count += 1;

--- a/tst/unit/hashtable_test.cc
+++ b/tst/unit/hashtable_test.cc
@@ -73,7 +73,7 @@ static JValue makeArray(size_t sz, size_t offset = 0) {
     JValue j;
     j.SetArray();
     for (size_t i = 0; i < sz; ++i) {
-        j.PushBack(JValue(i + offset), allocator);
+        j.PushBack(JValue(static_cast<uint64_t>(i + offset)), allocator);
     }
     return j;
 }


### PR DESCRIPTION
- Enabled `compile_commands.json` in `CMake` for better code completion
- Do not call "std::move" on temporary variables
- Fixed formatting errors (`printf` wrong identifiers)
- Fixed invalid struct definitions
- Fixed unused parameter values (by adding: `[[maybe_unused]]`)
- Fixed: multiple symbols link error on clang by decorating Valkey methods as `attribute(weak)`