### PR TITLE
Modify JSON Tests to allow connection to external server.

### DIFF
--- a/tst/integration/json_test_case.py
+++ b/tst/integration/json_test_case.py
@@ -15,8 +15,22 @@ class SimpleTestCase(ValkeyTestCase):
     '''
     @pytest.fixture(autouse=True)
     def setup_test(self, setup):
-        server_path = f"{os.path.dirname(os.path.realpath(__file__))}/.build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
-        self.server, self.client = self.create_server(testdir = self.testdir,  server_path=server_path)
+        use_external = os.environ.get("VALKEY_EXTERNAL_SERVER", "false").lower() == "true"
+        
+        if use_external:
+            # Use external server
+            external_host = os.environ.get("VALKEY_HOST", "localhost")
+            external_port = int(os.environ.get("VALKEY_PORT", "6379"))
+            self.server, self.client = self.create_server(
+                testdir=self.testdir,
+                bind_ip=external_host,
+                port=external_port,
+                external_server=True
+            )
+        else:
+            # Original local server
+            server_path = f"{os.path.dirname(os.path.realpath(__file__))}/.build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
+            self.server, self.client = self.create_server(testdir=self.testdir, server_path=server_path)
 
     def teardown(self):
         if self.is_connected():
@@ -47,9 +61,24 @@ class JsonTestCase(SimpleTestCase):
 
     @pytest.fixture(autouse=True)
     def setup_test(self, setup):
-        server_path = f"{os.path.dirname(os.path.realpath(__file__))}/.build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
-        args = {'loadmodule': os.getenv('MODULE_PATH'), "enable-debug-command": "local", 'enable-protected-configs': 'yes'}
-        self.server, self.client = self.create_server(testdir = self.testdir,  server_path=server_path, args=args)
+        use_external = os.environ.get("VALKEY_EXTERNAL_SERVER", "false").lower() == "true"
+        
+        if use_external:
+            # Use external server
+            external_host = os.environ.get("VALKEY_HOST", "localhost")
+            external_port = int(os.environ.get("VALKEY_PORT", "6379"))
+            self.server, self.client = self.create_server(
+                testdir=self.testdir,
+                bind_ip=external_host,
+                port=external_port,
+                external_server=True
+            )
+            logging.info("Using external valkey-bundle server with JSON module")
+        else:
+            # Original local server
+            server_path = f"{os.path.dirname(os.path.realpath(__file__))}/.build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
+            args = {'loadmodule': os.getenv('MODULE_PATH'), "enable-debug-command": "local", 'enable-protected-configs': 'yes'}
+            self.server, self.client = self.create_server(testdir=self.testdir, server_path=server_path, args=args)
 
         self.error_class = ErrorStringTester
 

--- a/tst/integration/json_test_case.py
+++ b/tst/integration/json_test_case.py
@@ -73,7 +73,6 @@ class JsonTestCase(SimpleTestCase):
                 port=external_port,
                 external_server=True
             )
-            logging.info("Using external valkey-bundle server with JSON module")
         else:
             # Original local server
             server_path = f"{os.path.dirname(os.path.realpath(__file__))}/.build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"

--- a/tst/integration/test_json_basic.py
+++ b/tst/integration/test_json_basic.py
@@ -179,7 +179,6 @@ class TestJsonBasic(JsonTestCase):
                 port=external_port,
                 external_server=True
             )
-            logging.info("Using external valkey-bundle server for TestJsonBasic")
         else:
             # Original local server setup
             server_path = f"{os.path.dirname(os.path.realpath(__file__))}/.build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"

--- a/tst/integration/test_json_basic.py
+++ b/tst/integration/test_json_basic.py
@@ -166,9 +166,25 @@ class TestJsonBasic(JsonTestCase):
 
     @pytest.fixture(autouse=True)
     def setup_test(self, setup):
-        server_path = f"{os.path.dirname(os.path.realpath(__file__))}/.build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
-        args = {'loadmodule': os.getenv('MODULE_PATH'), "enable-debug-command": "local", 'enable-protected-configs': 'yes'}
-        self.server, self.client = self.create_server(testdir = self.testdir,  server_path=server_path, args=args)
+        # Check if we should use external server
+        use_external = os.environ.get("VALKEY_EXTERNAL_SERVER", "false").lower() == "true"
+        
+        if use_external:
+            # Use external server
+            external_host = os.environ.get("VALKEY_HOST", "localhost")
+            external_port = int(os.environ.get("VALKEY_PORT", "6379"))
+            self.server, self.client = self.create_server(
+                testdir=self.testdir,
+                bind_ip=external_host,
+                port=external_port,
+                external_server=True
+            )
+            logging.info("Using external valkey-bundle server for TestJsonBasic")
+        else:
+            # Original local server setup
+            server_path = f"{os.path.dirname(os.path.realpath(__file__))}/.build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
+            args = {'loadmodule': os.getenv('MODULE_PATH'), "enable-debug-command": "local", 'enable-protected-configs': 'yes'}
+            self.server, self.client = self.create_server(testdir=self.testdir, server_path=server_path, args=args)
 
         self.error_class = ErrorStringTester
         self.setup_data()

--- a/tst/integration/test_rdb.py
+++ b/tst/integration/test_rdb.py
@@ -39,7 +39,6 @@ class TestRdb(JsonTestCase):
                 port=external_port,
                 external_server=True
             )
-            logging.info("Using external valkey-bundle server for TestJsonBasic")
         else:
             # Original local server setup
             server_path = f"{os.path.dirname(os.path.realpath(__file__))}/.build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"

--- a/tst/integration/test_rdb.py
+++ b/tst/integration/test_rdb.py
@@ -25,10 +25,26 @@ class TestRdb(JsonTestCase):
             'JSON.SET', 'store', '.', self.data_store)
 
     @pytest.fixture(autouse=True)
-    def setup_test(self):
-        server_path = f"{os.path.dirname(os.path.realpath(__file__))}/.build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
-        args = {'loadmodule': os.getenv('MODULE_PATH'), "enable-debug-command": "local", 'enable-protected-configs': 'yes'}
-        self.server, self.client = self.create_server(testdir = self.testdir,  server_path=server_path, args=args)
+    def setup_test(self, setup):
+        # Check if we should use external server
+        use_external = os.environ.get("VALKEY_EXTERNAL_SERVER", "false").lower() == "true"
+        
+        if use_external:
+            # Use external server
+            external_host = os.environ.get("VALKEY_HOST", "localhost")
+            external_port = int(os.environ.get("VALKEY_PORT", "6379"))
+            self.server, self.client = self.create_server(
+                testdir=self.testdir,
+                bind_ip=external_host,
+                port=external_port,
+                external_server=True
+            )
+            logging.info("Using external valkey-bundle server for TestJsonBasic")
+        else:
+            # Original local server setup
+            server_path = f"{os.path.dirname(os.path.realpath(__file__))}/.build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
+            args = {'loadmodule': os.getenv('MODULE_PATH'), "enable-debug-command": "local", 'enable-protected-configs': 'yes'}
+            self.server, self.client = self.create_server(testdir=self.testdir, server_path=server_path, args=args)
 
         self.error_class = ErrorStringTester
         self.setup_data()


### PR DESCRIPTION
This change adds the ability to run tests against an external Valkey server instead of always starting a new one. It coincides with the changes made in the Valkey-Test-Framework (https://github.com/valkey-io/valkey-test-framework/pull/7)

External server mode: If we set the environment variable, `VALKEY_EXTERNAL_SERVER=true , when we run the bloom pytests we will connect to an existing Valkey server at the specified host and port.

Local server mode: If not set or false, we will continue with the original behavior of starting a new Valkey server with the module loaded