### PR TITLE
Release valkey-json 1.0.2

### DIFF
--- a/.config/typos.toml
+++ b/.config/typos.toml
@@ -1,0 +1,21 @@
+# See https://github.com/crate-ci/typos/blob/master/docs/reference.md to configure typos
+
+[files]
+extend-exclude = [
+    ".git/",
+    "deps/",
+    "tst/",
+    "build/",
+    "cmake-build-debug/",
+    "rapidjson/",
+    "CMakeLists.txt"
+]
+
+[default.extend-words]
+Valkey = "Valkey"
+valkey = "valkey"
+threadsave = "threadsave"
+
+[default.extend-identifiers]
+ctrlChar_2ndPart = "ctrlChar_2ndPart"
+INSERTs = "INSERTs"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        server_version: ['unstable', '8.0', '8.1']
+        server_version: ['unstable', '8.0', '8.1', '9.0']
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Set the server version
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        server_version: ['unstable', '8.0', '8.1']
+        server_version: ['unstable', '8.0', '8.1', '9.0']
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Set the server version
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        server_version: ['unstable', '8.0', '8.1']
+        server_version: ['unstable', '8.0', '8.1', '9.0']
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Set the server version
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        server_version: ['unstable', '8.0', '8.1']
+        server_version: ['unstable', '8.0', '8.1', '9.0']
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Set the server version

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,34 @@
+# A CI action that using codespell to check spell.
+# .github/.codespellrc is a config file.
+# .github/wordlist.txt is a list of words that will ignore word checks.
+# More details please check the following link:
+# https://github.com/codespell-project/codespell
+name: Spellcheck
+
+on:
+  push:
+  pull_request:
+
+concurrency:
+  group: spellcheck-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Spellcheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Install typos
+        uses: taiki-e/install-action@fe9759bf4432218c779595708e80a1aadc85cedc # v2.46.10
+        with:
+          tool: typos
+
+      - name: Spell check
+        run: typos --config=./.config/typos.toml

--- a/.github/workflows/trigger-json-release.yml
+++ b/.github/workflows/trigger-json-release.yml
@@ -1,0 +1,39 @@
+name: Trigger Valkey Bundle Update - JSON
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version of Valkey JSON module that was released
+        required: true
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine version
+        id: determine-vars
+        run: |
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            echo "Triggered by a release event."
+            VERSION=${{ github.event.release.tag_name }}
+          else
+            echo "Triggered by workflow_dispatch."
+            VERSION=${{ inputs.version }}
+          fi
+
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Trigger valkey-bundle update
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.EXTENSION_PAT }}
+          repository: ${{ github.repository_owner }}/valkey-bundle
+          event-type: json-release
+          client-payload: >
+            {
+              "version": "${{ steps.determine-vars.outputs.version }}",
+              "component": "json"
+            }

--- a/00-RELEASENOTES
+++ b/00-RELEASENOTES
@@ -1,6 +1,14 @@
 Valkey JSON 1.0 release notes
 ========================
 ================================================================================
+Valkey JSON 1.0.2 - Released Mon 8 September 2025
+================================================================================
+* Support building valkey-json on Clang/Apple (#69)
+* Workdflow to automatically trigger valkey-bundle release (#64)
+* Allow testing on external container server (#70)
+* Implement SharedAPI interface that mimics JSON.GET (#71)
+
+================================================================================
 Valkey JSON 1.0.1 - Released Thu 19 June 2025
 ================================================================================
 Improvements in the build script

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,27 @@ endif()
 project(ValkeyJSONModule VERSION 99.99.99 LANGUAGES C CXX) # Version is 99.99.99 for unstable branch
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-mismatched-tags -Wno-format")
+
+# Clang related adjustments
+set(COMPILER_IS_CLANG OFF)
 if (${CMAKE_C_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_C_COMPILER_ID} STREQUAL "AppleClang")
+    set(COMPILER_IS_CLANG ON)
+endif()
+
+if (COMPILER_IS_CLANG)
+    message(STATUS "Defining VALKEYMODULE_ATTR_COMMON => __attribute__((weak))")
     add_definitions(-DVALKEYMODULE_ATTR_COMMON=__attribute__\(\(weak\)\))
+endif()
+
+if(APPLE AND NOT COMPILER_IS_CLANG)
+    # Force clang compiler on macOS
+    find_program(CLANGPP "clang++")
+    find_program(CLANG "clang")
+    if(CLANG AND CLANGPP)
+          message(STATUS "Found ${CLANGPP}, ${CLANG}")
+          set(CMAKE_CXX_COMPILER ${CLANGPP})
+          set(CMAKE_C_COMPILER ${CLANG})
+    endif()
 endif()
 
 # ASAN build option

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.17)
 include(FetchContent)
 include(ExternalProject)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # Detect the system architecture
 EXECUTE_PROCESS(
     COMMAND uname -m
@@ -10,14 +12,24 @@ EXECUTE_PROCESS(
     OUTPUT_VARIABLE ARCHITECTURE
 )
 
-if("${ARCHITECTURE}" STREQUAL "x86_64" OR "${ARCHITECTURE}" STREQUAL "aarch64")
+if("${ARCHITECTURE}" STREQUAL "x86_64"
+   OR "${ARCHITECTURE}" STREQUAL "aarch64"
+   OR "${ARCHITECTURE}" STREQUAL "arm64")
     message("Building valkey-json for ${ARCHITECTURE}")
 else()
-    message(FATAL_ERROR "Unsupported architecture: ${ARCHITECTURE}. valkey-json is only supported on x86_64 and aarch64.")
+    message(
+        FATAL_ERROR
+            "Unsupported architecture: ${ARCHITECTURE}. valkey-json is only supported on x86_64, aarch64 and arm64"
+    )
 endif()
 
 # Project definition
 project(ValkeyJSONModule VERSION 99.99.99 LANGUAGES C CXX) # Version is 99.99.99 for unstable branch
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-mismatched-tags -Wno-format")
+if (${CMAKE_C_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_C_COMPILER_ID} STREQUAL "AppleClang")
+    add_definitions(-DVALKEYMODULE_ATTR_COMMON=__attribute__\(\(weak\)\))
+endif()
 
 # ASAN build option
 option(ENABLE_ASAN "Enable Address Sanitizer" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ else()
 endif()
 
 # Project definition
-project(ValkeyJSONModule VERSION 1.0.1 LANGUAGES C CXX)
+project(ValkeyJSONModule VERSION 1.0.2 LANGUAGES C CXX)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-mismatched-tags -Wno-format")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,7 @@ target_sources(${OBJECT_TARGET}
 	json/keytable.cc
 	json/memory.cc
 	json/json_api.cc
+	json/shared_api.cc
 )
 
 add_library(${JSON_MODULE_LIB} SHARED $<TARGET_OBJECTS:${OBJECT_TARGET}>)

--- a/src/commands/json.arrappend.json
+++ b/src/commands/json.arrappend.json
@@ -1,7 +1,7 @@
 {
     "JSON.ARRAPPEND": {
         "summary": "Append one or more values to the array values at the path.",
-        "complexity": "O(N) where N is the number of vaules",
+        "complexity": "O(N) where N is the number of values",
         "group": "json",
         "module_since": "1.0.0",
         "arity": -4,

--- a/src/json/dom.cc
+++ b/src/json/dom.cc
@@ -174,7 +174,7 @@ JsonUtilCode dom_verify_value(ValkeyModuleCtx *ctx, JDocument *doc, const char *
     Selector selector;
     JsonUtilCode rc = selector.prepareSetValues(doc->GetJValue(), json_path);
     if (rc != JSONUTIL_SUCCESS) return rc;
-    
+
     JParser new_val;
     if (new_val.Parse(new_val_json, new_val_size).HasParseError()) {
         return new_val.GetParseErrorCode();
@@ -670,7 +670,7 @@ JsonUtilCode dom_object_keys(JDocument *doc, const char *path,
         jsn::vector<jsn::string> keys;
         if (v->IsObject()) {
             for (auto &m : v->GetObject()) {
-                keys.push_back(std::move(jsn::string(m.name.GetString(), m.name.GetStringLength())));
+                keys.push_back(jsn::string(m.name.GetString(), m.name.GetStringLength()));
             }
         }
         vec.push_back(keys);
@@ -1101,27 +1101,27 @@ JsonUtilCode dom_value_type(JDocument *doc, const char *path, jsn::vector<jsn::s
     for (auto &v : selector.getResultSet()) {
         switch (v.first->GetType()) {
             case rapidjson::kNullType:
-                vec.push_back(std::move(jsn::string(TYPE_NAMES[0])));
+                vec.push_back(jsn::string(TYPE_NAMES[0]));
                 break;
             case rapidjson::kTrueType:
             case rapidjson::kFalseType:
-                vec.push_back(std::move(jsn::string(TYPE_NAMES[1])));
+                vec.push_back(jsn::string(TYPE_NAMES[1]));
                 break;
             case rapidjson::kStringType:
-                vec.push_back(std::move(jsn::string(TYPE_NAMES[2])));
+                vec.push_back(jsn::string(TYPE_NAMES[2]));
                 break;
             case rapidjson::kNumberType: {
                 if (v.first->IsDouble())
-                    vec.push_back(std::move(jsn::string(TYPE_NAMES[3])));
+                    vec.push_back(jsn::string(TYPE_NAMES[3]));
                 else
-                    vec.push_back(std::move(jsn::string(TYPE_NAMES[4])));
+                    vec.push_back(jsn::string(TYPE_NAMES[4]));
                 break;
             }
             case rapidjson::kObjectType:
-                vec.push_back(std::move(jsn::string(TYPE_NAMES[5])));
+                vec.push_back(jsn::string(TYPE_NAMES[5]));
                 break;
             case rapidjson::kArrayType:
-                vec.push_back(std::move(jsn::string(TYPE_NAMES[6])));
+                vec.push_back(jsn::string(TYPE_NAMES[6]));
                 break;
             default:
                 ValkeyModule_Assert(false);
@@ -1513,7 +1513,7 @@ JValue rdbLoadJValue(load_params *params) {
             return array;
         }
         default:
-            ValkeyModule_LogIOError(params->rdb, "error", "Invalid metadata code %lx", code);
+            ValkeyModule_LogIOError(params->rdb, "error", "Invalid metadata code %llx", code);
             params->status = JSONUTIL_INVALID_RDB_FORMAT;
             return JValue();
     }

--- a/src/json/dom.cc
+++ b/src/json/dom.cc
@@ -1437,7 +1437,7 @@ STATIC JValue readLegacyDoubleAsJValue(ValkeyModuleIO *rdb) {
 }
 
 /*
- * One instance of this is passed to all recursive invokations of rdbLoadJValue
+ * One instance of this is passed to all recursive invocations of rdbLoadJValue
  */
 typedef struct load_params {
     ValkeyModuleIO *rdb;

--- a/src/json/json.cc
+++ b/src/json/json.cc
@@ -27,15 +27,13 @@
  *    helper structs named as XXXCmdsArgs, and helper methods named as parseXXXCmdArgs, where XXX is command name.
  */
 
-#include "json/json.h"
 #include "json/dom.h"
-#include "json/rapidjson_includes.h"
-#include "json/alloc.h"
 #include "json/stats.h"
 #include "json/memory.h"
+#include "json/shared_api.h"
 #include "./include/valkeymodule.h"
+
 #include <string>
-#include <memory>
 #include <cmath>
 
 /* In unstable branch the module version is always "999999". */
@@ -171,6 +169,17 @@ bool json_is_instrument_enabled_dump_value_before_delete() {
 
 /* ============================== Helper Methods ============================== */
 
+/* Verify that an open Key is a JSON document 
+    * @param key - ValkeyModuleKey pointer.
+    * @return JSONUTIL_SUCCESS if the key is a valid document key, otherwise an error code.
+    */
+JsonUtilCode verify_open_doc_key(ValkeyModuleKey *key) {
+    if (ValkeyModule_KeyType(key) == VALKEYMODULE_KEYTYPE_EMPTY) return JSONUTIL_DOCUMENT_KEY_NOT_FOUND;
+    if (ValkeyModule_ModuleTypeGetType(key) != DocumentType) return JSONUTIL_NOT_A_DOCUMENT_KEY;
+    return JSONUTIL_SUCCESS;
+}
+
+
 /* Verify that the document key exists and is a document key.
  * @param key - OUTPUT parameter, pointer to ValkeyModuleKey pointer.
  */
@@ -178,9 +187,7 @@ STATIC JsonUtilCode verify_doc_key(ValkeyModuleCtx *ctx, ValkeyModuleString *rmK
                                                                                      bool readOnly = false) {
     *key = static_cast<ValkeyModuleKey*>(ValkeyModule_OpenKey(ctx, rmKey,
                                         readOnly?  VALKEYMODULE_READ : VALKEYMODULE_READ | VALKEYMODULE_WRITE));
-    if (ValkeyModule_KeyType(*key) == VALKEYMODULE_KEYTYPE_EMPTY) return JSONUTIL_DOCUMENT_KEY_NOT_FOUND;
-    if (ValkeyModule_ModuleTypeGetType(*key) != DocumentType) return JSONUTIL_NOT_A_DOCUMENT_KEY;
-    return JSONUTIL_SUCCESS;
+    return verify_open_doc_key(*key);                                        
 }
 
 /* Fetch JSON at a single path.
@@ -2044,6 +2051,35 @@ STATIC int reply_debug_memory_fields(jsn::vector<size_t> &vec, const bool is_v2_
     }
 }
 
+//
+// Provide testing for the SharedAPI interface.
+//
+// JSON.DEBUG TEST-SHARED-API <key> <path>
+//
+// Returns the fetched string
+// 
+STATIC int TestSharedApi(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    if (argc != 4) {
+        ValkeyModule_WrongArity(ctx);
+        return VALKEYMODULE_OK;
+    }
+    auto key = ValkeyModule_OpenKey(ctx, argv[2], VALKEYMODULE_READ);
+    if (!key) {
+        ValkeyModule_ReplyWithError(ctx, "Unknown key");
+        return VALKEYMODULE_OK;
+    }
+    ValkeyModuleString *result = nullptr;
+    SharedJSON_Get(key, ValkeyModule_StringPtrLen(argv[3], nullptr), &result);
+    if (result) {
+        ValkeyModule_ReplyWithString(ctx, result);
+        ValkeyModule_FreeString(ctx, result);
+    } else {
+        ValkeyModule_ReplyWithError(ctx, "Invalid Path");
+    }
+    ValkeyModule_CloseKey(key);
+    return VALKEYMODULE_OK;
+}
+
 int Command_JsonDebug(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
     ValkeyModule_AutoMemory(ctx);
 
@@ -2214,6 +2250,17 @@ int Command_JsonDebug(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc)
             ValkeyModule_ReplyWithLongLong(ctx, it->second);
         }
         return VALKEYMODULE_OK;
+    } else if (!strcasecmp(subcmd, "TEST-SHARED-API")) {
+        // Testing for SharedAPI Interface
+        if (ValkeyModule_IsKeysPositionRequest(ctx)) {
+            if (argc < 3) {
+                return VALKEYMODULE_ERR;
+            } else {
+                ValkeyModule_KeyAtPos(ctx, 2);
+                return VALKEYMODULE_OK;
+            }
+        }
+        return TestSharedApi(ctx, argv, argc);
     } else if (!strcasecmp(subcmd, "HELP")) {
         if (ValkeyModule_IsKeysPositionRequest(ctx)) {
             return VALKEYMODULE_ERR;
@@ -2236,6 +2283,7 @@ int Command_JsonDebug(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc)
         cmds.push_back("JSON.DEBUG KEYTABLE-CHECK - Extended KeyTable integrity check");
         cmds.push_back("JSON.DEBUG KEYTABLE-CORRUPT <name> - Intentionally corrupt KeyTable handle counts");
         cmds.push_back("JSON.DEBUG KEYTABLE-DISTRIBUTION <topN> - Find and count topN longest runs in KeyTable");
+        cmds.push_back("JSON.DEBUG TEST-SHARED-API <key> <path> - Provide testing for Shared api interface for search");
 
         ValkeyModule_ReplyWithArray(ctx, cmds.size());
         for (auto& s : cmds) ValkeyModule_ReplyWithSimpleString(ctx, s.c_str());
@@ -2914,6 +2962,10 @@ extern "C" int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx) {
         ValkeyModule_Log(ctx, "warning", "Failed to create subcommand KEYTABLE-DISTRIBUTION for command JSON.DEBUG.");
         return VALKEYMODULE_ERR;
     }
+    if (ValkeyModule_CreateSubcommand(parent, "TEST-SHARED-API", Command_JsonDebug, "", 2, 2, 1) == VALKEYMODULE_ERR) {
+        ValkeyModule_Log(ctx, "warning", "Failed to create subcommand TEST_SHARED-API for command JSON.DEBUG.");
+        return VALKEYMODULE_ERR;
+    }
 
     // key-spec flags categories
     const uint64_t ks_read_write_update = VALKEYMODULE_CMD_KEY_RW | VALKEYMODULE_CMD_KEY_UPDATE;
@@ -3035,6 +3087,8 @@ extern "C" int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx) {
 
     // Register module configs
     if (registerModuleConfigs(ctx) == VALKEYMODULE_ERR) return VALKEYMODULE_ERR;
+
+    SharedAPI_Register(ctx);
 
     return VALKEYMODULE_OK;
 }

--- a/src/json/json.cc
+++ b/src/json/json.cc
@@ -36,7 +36,7 @@
 #include <string>
 #include <cmath>
 
-#define MODULE_VERSION 10010
+#define MODULE_VERSION 10002 /* version 1.0.2 */
 #define MODULE_NAME "json"
 /* The release stage is used in order to provide release status information.
  * In unstable branch the status is always "dev".

--- a/src/json/json.cc
+++ b/src/json/json.cc
@@ -10,7 +10,7 @@
  * Design Considerations:
  * 1. All JSON CRUD operations should be delegated to the DOM module.
  * 2. Shared utility/helper code should reside in the UTIL module.
- * 3. When invoking a DOM or UTIL method tha returns a heap-allocated object, the caller must release the memory
+ * 3. When invoking a DOM or UTIL method the returns a heap-allocated object, the caller must release the memory
  *    after consuming it.
  * 4. The first line of every command handler should be: "ValkeyModule_AutoMemory(ctx);". This is for enabling
  *    auto memory management for the command.
@@ -1509,7 +1509,7 @@ STATIC void reply_arrpop(jsn::vector<rapidjson::StringBuffer> &vec, const bool i
     if (!is_v2_path) {
         // Legacy path: return a single value, which is the first value.
         for (auto it = vec.begin(); it != vec.end(); it++) {
-            if (it->GetLength() != 0) {  // emtpy indicates empty array or wrong type
+            if (it->GetLength() != 0) {  // empty indicates empty array or wrong type
                 ValkeyModule_ReplyWithStringBuffer(ctx, it->GetString(), it->GetLength());
                 return;
             }
@@ -1519,7 +1519,7 @@ STATIC void reply_arrpop(jsn::vector<rapidjson::StringBuffer> &vec, const bool i
         // JSONPath: return an array of lengths.
         ValkeyModule_ReplyWithArray(ctx, vec.size());
         for (auto it = vec.begin(); it != vec.end(); it++) {
-            if (it->GetLength() == 0) {  // emtpy indicates empty array or wrong type
+            if (it->GetLength() == 0) {  // empty indicates empty array or wrong type
                 ValkeyModule_ReplyWithNull(ctx);
             } else {
                 ValkeyModule_ReplyWithStringBuffer(ctx, it->GetString(), it->GetLength());

--- a/src/json/json.h
+++ b/src/json/json.h
@@ -1,6 +1,9 @@
 #ifndef VALKEYJSONMODULE_JSON_H_
 #define VALKEYJSONMODULE_JSON_H_
 
+#include "./include/valkeymodule.h"
+#include "json/util.h"
+
 #include <stddef.h>
 
 size_t json_get_max_document_size();
@@ -16,6 +19,8 @@ bool json_is_instrument_enabled_delete();
 bool json_is_instrument_enabled_dump_doc_before();
 bool json_is_instrument_enabled_dump_doc_after();
 bool json_is_instrument_enabled_dump_value_before_delete();
+
+JsonUtilCode verify_open_doc_key(ValkeyModuleKey *key);
 
 #define DOUBLE_CHARS_CUTOFF 24
 

--- a/src/json/keytable.cc
+++ b/src/json/keytable.cc
@@ -302,7 +302,7 @@ struct KeyTable_Shard {
         if (duration == 0) duration = 1;
         uint64_t keys_per_second = (size / duration) * 1000;
         ValkeyModule_Log(nullptr, "notice",
-                        "Keytable Resize to %zu completed in %lu ms (%lu / sec)",
+                        "Keytable Resize to %zu completed in %llu ms (%llu / sec)",
                         capacity, duration, keys_per_second);
     }
 

--- a/src/json/keytable.h
+++ b/src/json/keytable.h
@@ -161,7 +161,7 @@ struct KeyTable_Layout {
 
  protected:
     KeyTable_Layout();               // Nobody gets to create one.
-    friend class KeyTable_Shard;     // Only class allowed to manipulate reference count
+    friend struct KeyTable_Shard;    // Only class allowed to manipulate reference count
     bool incrRefCount() const;       // true => saturated
     size_t decrRefCount() const;     // returns current count
     size_t original_hash;            // Remember original hash
@@ -233,7 +233,7 @@ struct KeyTable_Handle {
     }
 
  private:
-    friend class KeyTable;
+    friend struct KeyTable;
     friend struct KeyTable_Shard;
 
     KeyTable_Handle(KeyTable_Layout *ptr, size_t hashCode) : theHandle(ptr, hashCode) {}
@@ -369,7 +369,7 @@ struct KeyTable {
     size_t getNumShards() const { return numShards; }
 
  private:
-    friend class KeyTable_Shard;
+    friend struct KeyTable_Shard;
     size_t shardNumberFromHash(size_t hash);
     size_t hashcodeFromHash(size_t hash);
     KeyTable_Shard* shards;

--- a/src/json/memory.cc
+++ b/src/json/memory.cc
@@ -63,7 +63,7 @@ STATIC void *memory_realloc_without_traps(void *ptr, size_t new_size) {
 //
 
 //
-// This word of data preceeds the memory allocation as seen by the client.
+// This word of data precedes the memory allocation as seen by the client.
 // The presence of the length is redundant with calling the low-level allocators memory-size function,
 // but that function can be fairly expensive, so by duplicating here we optimize the run-time cost.
 //

--- a/src/json/selector.cc
+++ b/src/json/selector.cc
@@ -588,7 +588,7 @@ void Lexer::unescape(const std::string_view &input, jsn::stringstream &ss) {
                         // output the internal representation of the control character
                         ss << ctrlChars[ptr - ctrlChar_2ndPart];
                     } else {
-                        // This blackslash does not represent an escaped control character.
+                        // This backslash does not represent an escaped control character.
                         ss << input[i];
                     }
                 }

--- a/src/json/shared_api.cc
+++ b/src/json/shared_api.cc
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025, valkey-json contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#include "shared_api.h"
+#include "json/json.h"
+#include "json/dom.h"
+#include "json/selector.h"
+
+void SharedAPI_Register(ValkeyModuleCtx *ctx) {
+    if(ValkeyModule_ExportSharedAPI(ctx, "JSON_GetValue", (void *)SharedJSON_Get) != VALKEYMODULE_OK) {
+        ValkeyModule_Assert(false);
+    }
+}
+
+int SharedJSON_Get(ValkeyModuleKey *key, const char *path, ValkeyModuleString **result) {
+    if (verify_open_doc_key(key) != JSONUTIL_SUCCESS) {
+        return VALKEYMODULE_ERR;
+    }
+    // Fetch the document from the key
+    JDocument *doc = static_cast<JDocument *>(ValkeyModule_ModuleTypeGetValue(key));
+    rapidjson::StringBuffer output;
+    if (dom_get_value_as_str(doc, path, nullptr, output) == JSONUTIL_SUCCESS) {
+        *result = ValkeyModule_CreateString(nullptr, output.GetString(), output.GetLength());
+        return VALKEYMODULE_OK;
+    } else {
+        return VALKEYMODULE_ERR;
+    }
+}
+

--- a/src/json/shared_api.h
+++ b/src/json/shared_api.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025, valkey-json contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#ifndef VALKEYJSONMODULE_SHARED_API_H_
+#define VALKEYJSONMODULE_SHARED_API_H_
+
+#include "./include/valkeymodule.h"
+
+#include <stddef.h>
+
+//
+// Fetch JSON text associated with "path".
+//
+// Errors:
+//
+//   If the key isn't JSON, then you'll get VALKEYMODULE_ERR for the return.
+//   If the key is JSON, but the path doesn't identify anything, then you'll get a nullptr for the result.
+//   Otherwise you get the JSON text that matches the path.
+//
+int SharedJSON_Get(ValkeyModuleKey *key, const char *path, ValkeyModuleString **result);
+
+//
+// Internal.
+//
+void SharedAPI_Register(ValkeyModuleCtx *ctx);
+
+
+#endif  // VALKEYJSONMODULE_SHARED_API_H_

--- a/src/json/stats.cc
+++ b/src/json/stats.cc
@@ -21,7 +21,7 @@ static pthread_key_t thread_local_mem_counter_key;
  * Use atomic integers due to possible multi-threading execution of rdb_load and
  * also the overhead of atomic operations are negligible.
  */
-typedef struct {
+typedef struct _JsonStats {
     std::atomic_ullong used_mem;  // global used memory counter
     std::atomic_ullong num_doc_keys;
     std::atomic_ullong max_depth_ever_seen;

--- a/src/json/stats.h
+++ b/src/json/stats.h
@@ -84,7 +84,7 @@ uint32_t jsonstats_find_bucket(size_t size);
  * We don't track the logical bytes themselves here as they are tracked by Skyhook Metering.
  * We are using size_t to match Valkey Module API for Data Metering.
  */
-typedef struct {
+typedef struct _LogicalStats {
     std::atomic_size_t boolean_count;  // 16 bytes
     std::atomic_size_t number_count;  // 16 bytes
     std::atomic_size_t sum_extra_numeric_chars;  // 1 byte per char

--- a/src/rapidjson/document.h
+++ b/src/rapidjson/document.h
@@ -1749,7 +1749,7 @@ public:
     /*! This function do not deallocate memory in the array, i.e. the capacity is unchanged.
         \note Linear time complexity.
     */
-    void Clear(Allocator &allocator) {
+    void Clear([[maybe_unused]] Allocator &allocator) {
         GenericValue* e = GetElementsPointer();
         for (GenericValue* v = e; v != e + data_.a.size; ++v)
             v->~GenericValue();
@@ -1859,7 +1859,7 @@ public:
     /*!
         \note Constant time complexity.
     */
-    GenericValue& PopBack(Allocator& allocator) {
+    GenericValue& PopBack([[maybe_unused]] Allocator& allocator) {
         RAPIDJSON_ASSERT(!Empty());
         GetElementsPointer()[--data_.a.size].~GenericValue();
         return *this;
@@ -2614,7 +2614,7 @@ private:
         //
         // Move the members from the copy into the new hashtable
         //
-        size_t object_member_count = 0;
+        [[maybe_unused]] size_t object_member_count = 0;
         size_t object_num_member_chars = 0;
         for (MemberIterator i = me.MemberBegin(); i != me.MemberEnd(); ++i) {
             object_member_count += 1;

--- a/src/rapidjson/document.h
+++ b/src/rapidjson/document.h
@@ -916,7 +916,7 @@ public:
     /*!
         \param a An array obtained by \c GetArray().
         \note \c Array is always pass-by-value.
-        \note the source array is moved into this value and the sourec array becomes empty.
+        \note the source array is moved into this value and the source array becomes empty.
     */
     GenericValue(Array a) RAPIDJSON_NOEXCEPT : data_(a.value_.data_) {
         a.value_.data_ = Data();

--- a/src/rapidjson/reader.h
+++ b/src/rapidjson/reader.h
@@ -1012,7 +1012,7 @@ private:
 //!@endcond
 
         for (;;) {
-            // Scan and copy string before "\\\"" or < 0x20. This is an optional optimzation.
+            // Scan and copy string before "\\\"" or < 0x20. This is an optional optimization.
             if (!(parseFlags & kParseValidateEncodingFlag))
                 ScanCopyUnescapedString(is, os);
 
@@ -2053,7 +2053,7 @@ private:
         case IterativeParsingObjectInitialState:
         case IterativeParsingArrayInitialState:
         {
-            // Push the state(Element or MemeberValue) if we are nested in another array or value of member.
+            // Push the state(Element or MemberValue) if we are nested in another array or value of member.
             // In this way we can get the correct state on ObjectFinish or ArrayFinish by frame pop.
             IterativeParsingState n = src;
             if (src == IterativeParsingArrayInitialState || src == IterativeParsingElementDelimiterState)

--- a/tst/integration/json_test_case.py
+++ b/tst/integration/json_test_case.py
@@ -15,8 +15,22 @@ class SimpleTestCase(ValkeyTestCase):
     '''
     @pytest.fixture(autouse=True)
     def setup_test(self, setup):
-        server_path = f"{os.path.dirname(os.path.realpath(__file__))}/.build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
-        self.server, self.client = self.create_server(testdir = self.testdir,  server_path=server_path)
+        use_external = os.environ.get("VALKEY_EXTERNAL_SERVER", "false").lower() == "true"
+        
+        if use_external:
+            # Use external server
+            external_host = os.environ.get("VALKEY_HOST", "localhost")
+            external_port = int(os.environ.get("VALKEY_PORT", "6379"))
+            self.server, self.client = self.create_server(
+                testdir=self.testdir,
+                bind_ip=external_host,
+                port=external_port,
+                external_server=True
+            )
+        else:
+            # Original local server
+            server_path = f"{os.path.dirname(os.path.realpath(__file__))}/.build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
+            self.server, self.client = self.create_server(testdir=self.testdir, server_path=server_path)
 
     def teardown(self):
         if self.is_connected():
@@ -47,9 +61,23 @@ class JsonTestCase(SimpleTestCase):
 
     @pytest.fixture(autouse=True)
     def setup_test(self, setup):
-        server_path = f"{os.path.dirname(os.path.realpath(__file__))}/.build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
-        args = {'loadmodule': os.getenv('MODULE_PATH'), "enable-debug-command": "local", 'enable-protected-configs': 'yes'}
-        self.server, self.client = self.create_server(testdir = self.testdir,  server_path=server_path, args=args)
+        use_external = os.environ.get("VALKEY_EXTERNAL_SERVER", "false").lower() == "true"
+        
+        if use_external:
+            # Use external server
+            external_host = os.environ.get("VALKEY_HOST", "localhost")
+            external_port = int(os.environ.get("VALKEY_PORT", "6379"))
+            self.server, self.client = self.create_server(
+                testdir=self.testdir,
+                bind_ip=external_host,
+                port=external_port,
+                external_server=True
+            )
+        else:
+            # Original local server
+            server_path = f"{os.path.dirname(os.path.realpath(__file__))}/.build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
+            args = {'loadmodule': os.getenv('MODULE_PATH'), "enable-debug-command": "local", 'enable-protected-configs': 'yes'}
+            self.server, self.client = self.create_server(testdir=self.testdir, server_path=server_path, args=args)
 
         self.error_class = ErrorStringTester
 

--- a/tst/integration/test_json_basic.py
+++ b/tst/integration/test_json_basic.py
@@ -4213,7 +4213,7 @@ class TestJsonBasic(JsonTestCase):
         cmd_arity = [('MEMORY', -3), ('FIELDS', -3), ('DEPTH', 3), ('HELP', 2),
                      ('MAX-DEPTH-KEY', 2), ('MAX-SIZE-KEY',
                                             2), ('KEYTABLE-CHECK', 2), ('KEYTABLE-CORRUPT', 3),
-                     ('KEYTABLE-DISTRIBUTION', 3)]
+                     ('KEYTABLE-DISTRIBUTION', 3), ('TEST-SHARED-API', -2)]
         subcmd_dict = {f'JSON.DEBUG|{cmd}': arity for cmd, arity in cmd_arity}
 
         output = client.execute_command(
@@ -4335,3 +4335,23 @@ class TestJsonBasic(JsonTestCase):
         client.execute_command("json.numincrby", "k1", "$..b/c", "2")
         exp = "{\"a\":4.5,\"b/c\":9}"
         assert exp.encode() == client.execute_command("json.get", "k1")
+
+    def test_json_shared_api(self):
+        DATA = '''
+        {
+            "0": 0,
+            "1": true,
+            "2": "string",
+            "3": [0.0, 1.1, 2.0],
+            "4": {},
+            "5": {"0": 1, "1": "string"}
+        }
+        '''
+        client = self.server.get_new_client()
+        client.execute_command("json.set", "k1", ".", DATA)
+        print(client.execute_command("json.debug","help"))
+        for path in ["$.0", "$.1", "$.2", "$.3", "$.4", "$.5", "$5.0", "$5.1"]:
+            g = client.execute_command("json.get", "k1", path)
+            s = client.execute_command("json.debug", "test-shared-api", "k1", path)
+            print("For Path:", path, " json.get:", g, " shared-api:", s)
+            assert (g == s)

--- a/tst/integration/test_json_basic.py
+++ b/tst/integration/test_json_basic.py
@@ -166,9 +166,24 @@ class TestJsonBasic(JsonTestCase):
 
     @pytest.fixture(autouse=True)
     def setup_test(self, setup):
-        server_path = f"{os.path.dirname(os.path.realpath(__file__))}/.build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
-        args = {'loadmodule': os.getenv('MODULE_PATH'), "enable-debug-command": "local", 'enable-protected-configs': 'yes'}
-        self.server, self.client = self.create_server(testdir = self.testdir,  server_path=server_path, args=args)
+        # Check if we should use external server
+        use_external = os.environ.get("VALKEY_EXTERNAL_SERVER", "false").lower() == "true"
+        
+        if use_external:
+            # Use external server
+            external_host = os.environ.get("VALKEY_HOST", "localhost")
+            external_port = int(os.environ.get("VALKEY_PORT", "6379"))
+            self.server, self.client = self.create_server(
+                testdir=self.testdir,
+                bind_ip=external_host,
+                port=external_port,
+                external_server=True
+            )
+        else:
+            # Original local server setup
+            server_path = f"{os.path.dirname(os.path.realpath(__file__))}/.build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
+            args = {'loadmodule': os.getenv('MODULE_PATH'), "enable-debug-command": "local", 'enable-protected-configs': 'yes'}
+            self.server, self.client = self.create_server(testdir=self.testdir, server_path=server_path, args=args)
 
         self.error_class = ErrorStringTester
         self.setup_data()

--- a/tst/integration/test_rdb.py
+++ b/tst/integration/test_rdb.py
@@ -25,10 +25,25 @@ class TestRdb(JsonTestCase):
             'JSON.SET', 'store', '.', self.data_store)
 
     @pytest.fixture(autouse=True)
-    def setup_test(self):
-        server_path = f"{os.path.dirname(os.path.realpath(__file__))}/.build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
-        args = {'loadmodule': os.getenv('MODULE_PATH'), "enable-debug-command": "local", 'enable-protected-configs': 'yes'}
-        self.server, self.client = self.create_server(testdir = self.testdir,  server_path=server_path, args=args)
+    def setup_test(self, setup):
+        # Check if we should use external server
+        use_external = os.environ.get("VALKEY_EXTERNAL_SERVER", "false").lower() == "true"
+        
+        if use_external:
+            # Use external server
+            external_host = os.environ.get("VALKEY_HOST", "localhost")
+            external_port = int(os.environ.get("VALKEY_PORT", "6379"))
+            self.server, self.client = self.create_server(
+                testdir=self.testdir,
+                bind_ip=external_host,
+                port=external_port,
+                external_server=True
+            )
+        else:
+            # Original local server setup
+            server_path = f"{os.path.dirname(os.path.realpath(__file__))}/.build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
+            args = {'loadmodule': os.getenv('MODULE_PATH'), "enable-debug-command": "local", 'enable-protected-configs': 'yes'}
+            self.server, self.client = self.create_server(testdir=self.testdir, server_path=server_path, args=args)
 
         self.error_class = ErrorStringTester
         self.setup_data()

--- a/tst/unit/hashtable_test.cc
+++ b/tst/unit/hashtable_test.cc
@@ -73,7 +73,7 @@ static JValue makeArray(size_t sz, size_t offset = 0) {
     JValue j;
     j.SetArray();
     for (size_t i = 0; i < sz; ++i) {
-        j.PushBack(JValue(i + offset), allocator);
+        j.PushBack(JValue(static_cast<uint64_t>(i + offset)), allocator);
     }
     return j;
 }


### PR DESCRIPTION
```
================================================================================
Valkey JSON 1.0.2 - Released Mon 8 September 2025
================================================================================
* Support building valkey-json on Clang/Apple (#69)
* Workdflow to automatically trigger valkey-bundle release (#64)
* Allow testing on external container server (#70)
* Implement SharedAPI interface that mimics JSON.GET (#71)
```