### PR TITLE
Fix #86: Upgrade pytest and add setuptools to fix test suite

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 valkey
-pytest==6
+pytest==7.4.3
 pytest-html
+setuptools


### PR DESCRIPTION
Upgraded `pytest` to 7.4.3, which resolves existing integration test failures.

Also added `setuptools` to `requirements.txt` to specifically address the common Python error "ModuleNotFoundError: No module named 'pkg_resources'" during test execution.