### PR TITLE
Fix build on mac by using correct format specifier

### DIFF
--- a/src/json/dom.cc
+++ b/src/json/dom.cc
@@ -1513,7 +1513,7 @@ JValue rdbLoadJValue(load_params *params) {
             return array;
         }
         default:
-            ValkeyModule_LogIOError(params->rdb, "error", "Invalid metadata code %lx", code);
+            ValkeyModule_LogIOError(params->rdb, "error", "Invalid metadata code %llx", code);
             params->status = JSONUTIL_INVALID_RDB_FORMAT;
             return JValue();
     }

--- a/src/json/keytable.cc
+++ b/src/json/keytable.cc
@@ -302,7 +302,7 @@ struct KeyTable_Shard {
         if (duration == 0) duration = 1;
         uint64_t keys_per_second = (size / duration) * 1000;
         ValkeyModule_Log(nullptr, "notice",
-                        "Keytable Resize to %zu completed in %lu ms (%lu / sec)",
+                        "Keytable Resize to %zu completed in %llu ms (%llu / sec)",
                         capacity, duration, keys_per_second);
     }
 


### PR DESCRIPTION
This fixes #91. Change format specifiers in two printf statements to allow them to build on mac. These flags raise a warning and the `-Werror` flag means that they are treated as errors.
Another suggestion was to use the `-Wno-format` flag along with `-Werror`. If this is preferred, let me know.