### PR TITLE
Fix GCC 16 build failure

### DIFF
--- a/src/rapidjson/document.h
+++ b/src/rapidjson/document.h
@@ -2615,7 +2615,7 @@ private:
         // Move the members from the copy into the new hashtable
         //
         [[maybe_unused]] size_t object_member_count = 0;
-        size_t object_num_member_chars = 0;
+        [[maybe_unused]] size_t object_num_member_chars = 0;
         for (MemberIterator i = me.MemberBegin(); i != me.MemberEnd(); ++i) {
             object_member_count += 1;
             object_num_member_chars += i->name.GetStringLength();


### PR DESCRIPTION
Fixes #96

### Problem

GCC 16 (shipped with Fedora 44) has stricter detection for unused-but-set 
variables. The variable `object_num_member_chars` in vendored RapidJSON's 
`document.h` triggers `-Werror=unused-but-set-variable`, causing 
the build to fail.

### Fix

Added `[[maybe_unused]]` attribute to suppress the warning.

### Tested:
Built successfully with GCC 16 on Fedora 44:
<img width="878" height="958" alt="Screenshot 2026-02-19 at 2 36 40 PM" src="https://github.com/user-attachments/assets/57c3249f-7e12-470a-9e68-ded7c660dd29" />
