### PR TITLE
Cast int64 literals to double in jsonutil_is_int64 tests

### DIFF
--- a/tst/unit/util_test.cc
+++ b/tst/unit/util_test.cc
@@ -58,8 +58,8 @@ TEST_F(UtilTest, testIsInt64) {
     EXPECT_TRUE(jsonutil_is_int64(INT16_MIN));
     EXPECT_TRUE(jsonutil_is_int64(INT32_MAX));
     EXPECT_TRUE(jsonutil_is_int64(INT32_MIN));
-    EXPECT_TRUE(jsonutil_is_int64(INT64_MAX >> 1));
-    EXPECT_TRUE(jsonutil_is_int64(8223372036854775807LL));
+    EXPECT_TRUE(jsonutil_is_int64(static_cast<double>(INT64_MAX >> 1)));
+    EXPECT_TRUE(jsonutil_is_int64(static_cast<double>(8223372036854775807LL)));
     EXPECT_TRUE(jsonutil_is_int64(INT64_MIN));
     EXPECT_FALSE(jsonutil_is_int64(1e28));      // out of range of int64
     EXPECT_FALSE(jsonutil_is_int64(1.7e308));   // out of range of int64


### PR DESCRIPTION
## Summary

`./build.sh --unit` fails on newer clang (14+, including current Apple clang) because `-Wimplicit-const-int-float-conversion` is on under `-Wall` and the project sets `-Werror`. The two failing assertions in `tst/unit/util_test.cc`:

```
EXPECT_TRUE(jsonutil_is_int64(INT64_MAX >> 1));
EXPECT_TRUE(jsonutil_is_int64(8223372036854775807LL));
```

`jsonutil_is_int64` takes a `double`, so passing a `long long` literal triggers the implicit narrowing the warning flags.

This change makes the conversion explicit with `static_cast<double>(...)`. The test intent is preserved — both narrowed values still round-trip cleanly through `jsonutil_is_int64` (which does `double` → `int64` → `double` equality), so the assertions remain `TRUE`.

No production code changes; test-only.

## Test plan

- [x] `./build.sh --unit` succeeds (163/163 unit tests pass, including `UtilTest.testIsInt64`).
- [ ] CI build on existing toolchains stays green (no behavior change for older compilers that didn't emit the warning).
