### PR TITLE
Support running integration tests against an external Valkey server

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,7 @@ if(ENABLE_INTEGRATION_TESTS)
             COMMENT "Copied valkey-server to destination directory"
         )
     # Define valkey-test-framework commit id
-    set(VALKEY_TEST_FRAMEWORK_COMMIT "9fb28b74efd122324db00498a2fde6e5d281c90f" CACHE STRING "Valkey-test-framework commit to use")
+    set(VALKEY_TEST_FRAMEWORK_COMMIT "unstable" CACHE STRING "Valkey-test-framework commit to use")
 
     # Set the download directory for Valkey-test-framework
     set(VALKEY_TEST_FRAMEWORK_DOWNLOAD_DIR "${CMAKE_CURRENT_BINARY_DIR}/_deps/valkey-test-framework-src")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,7 @@ if(ENABLE_INTEGRATION_TESTS)
             COMMENT "Copied valkey-server to destination directory"
         )
     # Define valkey-test-framework commit id
-    set(VALKEY_TEST_FRAMEWORK_COMMIT "unstable" CACHE STRING "Valkey-test-framework commit to use")
+    set(VALKEY_TEST_FRAMEWORK_COMMIT "33cc62660ea94d49bd6ab27cb8c09b345fc5d577" CACHE STRING "Valkey-test-framework commit to use")
 
     # Set the download directory for Valkey-test-framework
     set(VALKEY_TEST_FRAMEWORK_DOWNLOAD_DIR "${CMAKE_CURRENT_BINARY_DIR}/_deps/valkey-test-framework-src")

--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ export ASAN_BUILD=true
 ./build.sh --integration
 ```
 
+By default, integration tests launch a local Valkey server.
+To run them against an external Valkey server instead (with the JSON module already loaded), set `VALKEY_EXTERNAL_SERVER=true`.
+The host and port can be customized via `VALKEY_HOST` (default `localhost`) and `VALKEY_PORT` (default `6379`):
+```text
+VALKEY_EXTERNAL_SERVER=true VALKEY_HOST=127.0.0.1 VALKEY_PORT=6379 ./build.sh --integration
+```
+
 ## Cleaning
 ```text
 # Clean build artifacts

--- a/tst/integration/run.sh
+++ b/tst/integration/run.sh
@@ -1,13 +1,5 @@
 #!/usr/bin/env bash
 
-# Sometimes processes are left running when test is cancelled.
-# Therefore, before build start, we kill all running test processes left from previous test run.
-echo "Kill old running test"
-pkill -9 -x Pytest || true
-pkill -9 -f "valkey-server.*:" || true
-pkill -9 -f Valgrind || true
-pkill -9 -f "valkey-benchmark" || true
-
 # If environment variable SERVER_VERSION is not set, default to "unstable"
 if [ -z "$SERVER_VERSION" ]; then
     echo "SERVER_VERSION environment variable is not set. Defaulting to \"unstable\"."


### PR DESCRIPTION
In #70, we modified the Python code to support it, but some content was
missing.

- README: document the VALKEY_EXTERNAL_SERVER / VALKEY_HOST / VALKEY_PORT
  environment variables for running integration tests against an
  already-running Valkey server with module loaded.

- tst/integration/run.sh: drop the "Kill old running test" pkill block
  so it does not terminate the user-managed external valkey-server
  before tests start.

- CMakeLists.txt: bump VALKEY_TEST_FRAMEWORK_COMMIT from a pinned hash
  to "unstable" to pull in the external-server support that is not
  available in the previously pinned commit.