### PR TITLE
Fix for crash when key contains ~

### DIFF
--- a/src/json/selector.cc
+++ b/src/json/selector.cc
@@ -616,6 +616,15 @@ struct pathCompare {
         JPointer ptr2 = JPointer(path2);
         size_t depth1 = ptr1.GetTokenCount();
         size_t depth2 = ptr2.GetTokenCount();
+
+        // Guard against invalid pointers. A malformed JSON pointer parses to zero tokens, and
+        // because depth is size_t, tokenArray[depth - 1] below would underflow to (size_t)-1 and
+        // read out of bounds. Fall back to a stable lexicographic ordering of the raw paths.
+        if (ptr1.HasError() || ptr2.HasError() || depth1 == 0 || depth2 == 0) {
+            if (depth1 != depth2) return depth1 > depth2;
+            return path1 > path2;
+        }
+
         if (depth1 != depth2) return depth1 > depth2;
 
         const JPointer::Token* tokenArray1 = ptr1.GetTokens();
@@ -2425,7 +2434,9 @@ void Selector::dedupe() {
 
 void Selector::escape_member_name_for_json_pointer(const std::string_view &member_name, std::ostringstream &oss) {
     for (char c : member_name) {
-        if (c == '/') {
+        if (c == '~') {
+            oss << "~0";
+        } else if (c == '/') {
             oss << "~1";
         } else {
             oss << c;

--- a/tst/unit/selector_test.cc
+++ b/tst/unit/selector_test.cc
@@ -1342,3 +1342,34 @@ TEST_F(SelectorTest, test_delete_insert) {
 
     dom_free_doc(d1);
 }
+
+// Deleting multiple object members whose keys contain a tilde via a multi-match path.
+TEST_F(SelectorTest, test_delete_tilde_keys) {
+    JDocument *d1;
+    const char *json = "{\"~\":1,\"~~\":2}";
+    JsonUtilCode rc = dom_parse(nullptr, json, strlen(json), &d1);
+    EXPECT_EQ(rc, JSONUTIL_SUCCESS);
+
+    size_t num_vals_deleted;
+    rc = dom_delete_value(d1, "$.*", num_vals_deleted);
+    EXPECT_EQ(rc, JSONUTIL_SUCCESS);
+    EXPECT_EQ(num_vals_deleted, 2);
+
+    dom_free_doc(d1);
+}
+
+// Recursive descent ($..*) over nested objects with tilde keys.
+TEST_F(SelectorTest, test_delete_tilde_keys_recursive) {
+    JDocument *d1;
+    const char *json = "{\"o\":{\"~\":1,\"~a\":2}}";
+    JsonUtilCode rc = dom_parse(nullptr, json, strlen(json), &d1);
+    EXPECT_EQ(rc, JSONUTIL_SUCCESS);
+
+    size_t num_vals_deleted;
+    rc = dom_delete_value(d1, "$..*", num_vals_deleted);
+    EXPECT_EQ(rc, JSONUTIL_SUCCESS);
+    EXPECT_EQ(num_vals_deleted, 3);
+
+    dom_free_doc(d1);
+}
+


### PR DESCRIPTION
Fix for issue: https://github.com/valkey-io/valkey-json/issues/104

Follow RFC 6901 where we set ~ as ~0 to distinguish a regular ~ compared to a ~ created from parsing a /. This fix will set ~ as ~0 for parsing. This will prevent crashes where we originally saw a ~ and expected it to be the start of parsing for a /. We have the order of tilde first so we don't double replace in the loop.


Tests: To make sure this doesnt get changed in the future we have the two scenarios listed in the issues as unit tests now. Without this change the tests would crash causing failures.