### PR TITLE
Fixing out of range crash

### DIFF
--- a/src/rapidjson/document.h
+++ b/src/rapidjson/document.h
@@ -32,6 +32,7 @@
 #include <new>     // placement new
 #include <limits>
 #include <atomic>
+#include <cstdlib>  // std::strtod
 #ifdef __cpp_lib_three_way_comparison
 #include <compare>
 #endif
@@ -1918,7 +1919,7 @@ public:
     */
     double GetDouble() const {
         RAPIDJSON_ASSERT(IsNumber());
-        if ((data_.f.flags & kDoubleFlag) != 0)                { return std::stod(DataString(data_)); }   // convert from string to double.
+        if ((data_.f.flags & kDoubleFlag) != 0)                { return std::strtod(DataString(data_), nullptr);}  // convert from string to double.
         if ((data_.f.flags & kIntFlag) != 0)                   return data_.n.i.i; // int -> double
         if ((data_.f.flags & kUintFlag) != 0)                  return data_.n.u.u; // unsigned -> double
         if ((data_.f.flags & kInt64Flag) != 0)                 return static_cast<double>(data_.n.i64); // int64_t -> double (may lose precision)

--- a/tst/unit/dom_test.cc
+++ b/tst/unit/dom_test.cc
@@ -777,6 +777,44 @@ TEST_F(DomTest, testNumIncrMultBy_string_value_overflow) {
     EXPECT_FALSE(isV2Path);
 }
 
+// Numbers outside the normal double range are kept in string form, and reading them via GetDouble()
+// must not crash. std::strtod instead returns a subnormal on underflow and +/-inf on overflow, so
+// underflow goes through as normal arithmetic and overflow is caught by the existing isinf check as
+// JSONUTIL_ADDITION_OVERFLOW.
+TEST_F(DomTest, testNumIncrBy_double_out_of_range) {
+    jsn::vector<double> res;
+    bool isV2Path;
+    JParser parser;
+
+    // Case 1: Stored value is normal, the increment 1e-308 is subnormal and is converted back via
+    // GetDouble() during the addition.
+    JsonUtilCode rc = dom_set_value(nullptr, doc1, ".foo", "1.5", false, false);
+    EXPECT_EQ(rc, JSONUTIL_SUCCESS);
+    rc = dom_increment_by(doc1, ".foo", &parser.Parse("1e-308", 6).GetJValue(), res, isV2Path);
+    EXPECT_EQ(rc, JSONUTIL_SUCCESS);
+    EXPECT_EQ(res.size(), 1);
+    EXPECT_EQ(res[0], 1.5 + 1e-308);
+    EXPECT_FALSE(isV2Path);
+
+    // Case 2: subnormal stored value, the stored 1e-308 is converted back via GetDouble().
+    rc = dom_set_value(nullptr, doc1, ".foo", "1e-308", false, false);
+    EXPECT_EQ(rc, JSONUTIL_SUCCESS);
+    rc = dom_increment_by(doc1, ".foo", &parser.Parse("5", 1).GetJValue(), res, isV2Path);
+    EXPECT_EQ(rc, JSONUTIL_SUCCESS);
+    EXPECT_EQ(res.size(), 1);
+    EXPECT_EQ(res[0], 1e-308 + 5);
+    EXPECT_FALSE(isV2Path);
+
+    // Case 3: overflow stored value, a plain-digit literal >= 10^309 (> DBL_MAX) is stored in
+    // string form. GetDouble() converts it to +inf, and the addition is caught as an overflow.
+    std::string big_literal = "1" + std::string(309, '0');
+    rc = dom_set_value(nullptr, doc1, ".foo", big_literal.c_str(), false, false);
+    EXPECT_EQ(rc, JSONUTIL_SUCCESS);
+    rc = dom_increment_by(doc1, ".foo", &parser.Parse("5", 1).GetJValue(), res, isV2Path);
+    EXPECT_EQ(rc, JSONUTIL_ADDITION_OVERFLOW);
+    EXPECT_FALSE(isV2Path);
+}
+
 TEST_F(DomTest, testToggle) {
     JsonUtilCode rc = dom_set_value(nullptr, doc1, ".foobool", "true", false, false);
     EXPECT_EQ(rc, JSONUTIL_SUCCESS);

--- a/tst/unit/selector_test.cc
+++ b/tst/unit/selector_test.cc
@@ -1289,6 +1289,25 @@ TEST_F(SelectorTest, test_delete) {
     dom_free_doc(d1);
 }
 
+TEST_F(SelectorTest, test_filterExpr_overflow_literal) {
+    JDocument *d1;
+    const char *input = "{\"n\":5}";
+    JsonUtilCode rc = dom_parse(nullptr, input, strlen(input), &d1);
+    EXPECT_EQ(rc, JSONUTIL_SUCCESS);
+
+    // Build the plain-digit literal 10^309, which is > DBL_MAX.
+    std::string big_literal = "1" + std::string(309, '0');
+    std::string path = "$[?(@.n > " + big_literal + ")]";
+
+    Selector selector;
+    rc = selector.getValues(*d1, path.c_str());
+    // 5 is not greater than 10^309, so no values match and it doesnt crash.
+    EXPECT_EQ(rc, JSONUTIL_SUCCESS);
+    EXPECT_EQ(selector.getResultSet().size(), 0);
+
+    dom_free_doc(d1);
+}
+
 TEST_F(SelectorTest, test_delete_insert) {
     JDocument *d1;
     const char *json = "{\"a\": { \"b\": { \"c1\": \"abc\", \"c2\": \"foo bar\", \"c3\": \"just a test\" }}}";

--- a/tst/unit/selector_test.cc
+++ b/tst/unit/selector_test.cc
@@ -1301,7 +1301,7 @@ TEST_F(SelectorTest, test_filterExpr_overflow_literal) {
 
     Selector selector;
     rc = selector.getValues(*d1, path.c_str());
-    // 5 is not greater than 10^309, so no values match and it doesnt crash.
+    // 5 is not greater than 10^309, so no values match and it doesn't crash.
     EXPECT_EQ(rc, JSONUTIL_SUCCESS);
     EXPECT_EQ(selector.getResultSet().size(), 0);
 


### PR DESCRIPTION
Fix for: https://github.com/valkey-io/valkey-json/issues/105

This fix uses the suggested change of switching to strtod. As this will convert overflows to inf, and not just throw an error. This library still works on subnormal values as well. We do not need an extra check for ERANGE from what I could tell as we are covered by the inf check in `JSONUTIL_ADDITION_OVERFLOW`

Two new tests are created the one in dom checks for three different cases, normal + subnormal, subnormal + normal then an overflow check.