### PR TITLE
Fix unbounded array Reserve in legacy RDB load

### DIFF
--- a/src/json/dom.cc
+++ b/src/json/dom.cc
@@ -1347,6 +1347,10 @@ enum meta_codes {
     JSON_METACODE_PAIR    = 0x80    // Codes an object Memory, a string(member name) and a JValue
 };
 
+// Cap pre-reservation for legacy RDB array loads: the declared count is untrusted
+// (RESTORE/replication), so limit upfront allocation; PushBack grows as elements arrive.
+static constexpr uint64_t JSON_RDB_ARRAY_RESERVE_CAP = 1ULL << 16;  // 65536 elements
+
 //
 // save a JValue, recurse as required for object and array
 //
@@ -1499,15 +1503,21 @@ JValue rdbLoadJValue(load_params *params) {
             uint64_t length = ValkeyModule_LoadUnsigned(params->rdb);
             JValue array;
             array.SetArray();
-            array.Reserve(length, allocator);
             if (params->nestLevel >= json_get_max_path_limit()) {
                 params->status = JSONUTIL_DOCUMENT_PATH_LIMIT_EXCEEDED;
                 ValkeyModule_LogIOError(params->rdb, "error", "document path limit exceeded");
                 return JValue();
             }
+            array.Reserve(std::min<uint64_t>(length, JSON_RDB_ARRAY_RESERVE_CAP), allocator);
             params->nestLevel++;
             while (length--) {
                 array.PushBack(rdbLoadJValue(params), allocator);
+                // Break on load failure or IO error to avoid unbounded loop.
+                if (params->status != JSONUTIL_SUCCESS || ValkeyModule_IsIOError(params->rdb)) {
+                    if (params->status == JSONUTIL_SUCCESS) params->status = JSONUTIL_INVALID_RDB_FORMAT;
+                    params->nestLevel--;
+                    return JValue();
+                }
             }
             params->nestLevel--;
             return array;
@@ -1543,6 +1553,12 @@ JsonUtilCode dom_load(JDocument **doc, ValkeyModuleIO *ctx, int encver) {
             params.nestLevel = 0;
             params.status = JSONUTIL_SUCCESS;
             JValue loadedValue = rdbLoadJValue(&params);
+            // Catch truncated-stream cases that didn't set status during recursion.
+            if (params.status == JSONUTIL_SUCCESS && ValkeyModule_IsIOError(ctx)) {
+                ValkeyModule_LogIOError(ctx, "warning",
+                    "IO error after rdbLoadJValue with success status; rejecting");
+                params.status = JSONUTIL_INVALID_RDB_FORMAT;
+            }
             if (params.status == JSONUTIL_SUCCESS) {
                 *doc = create_doc();
                 (*doc)->SetJValue(loadedValue);

--- a/tst/integration/test_rdb.py
+++ b/tst/integration/test_rdb.py
@@ -4,8 +4,81 @@ from valkeytests.conftest import resource_port_tracker
 import logging, os, pathlib
 import pytest
 from error_handlers import ErrorStringTester
+from valkey.exceptions import ResponseError
 
 logging.basicConfig(level=logging.DEBUG)
+
+
+# --- Helpers for crafting raw DUMP/RESTORE payloads (issue #107) ---
+
+_CRC64_POLY = 0xad93d23594c935a9
+
+
+def _reflect64(value):
+    """Reverse the bit order of a 64-bit integer."""
+    result = 0
+    for i in range(64):
+        if (value >> i) & 1:
+            result |= 1 << (63 - i)
+    return result
+
+
+def _build_crc64_table():
+    poly = _reflect64(_CRC64_POLY)
+    table = []
+    for n in range(256):
+        crc = n
+        for _ in range(8):
+            crc = (crc >> 1) ^ poly if (crc & 1) else (crc >> 1)
+        table.append(crc & 0xFFFFFFFFFFFFFFFF)
+    return table
+
+
+_CRC64_TABLE = _build_crc64_table()
+
+
+def crc64(data, crc=0):
+    """Valkey/Redis CRC-64 (Jones variant) over a byte string."""
+    for b in data:
+        crc = _CRC64_TABLE[(crc ^ b) & 0xFF] ^ (crc >> 8)
+    return crc & 0xFFFFFFFFFFFFFFFF
+
+
+def rdb_save_len(n):
+    """Encode n using Valkey's RDB length encoding."""
+    if n < (1 << 6):
+        return bytes([n])                                  # 6-bit length
+    elif n < (1 << 14):
+        return bytes([0x40 | (n >> 8), n & 0xFF])          # 14-bit length
+    elif n <= 0xFFFFFFFF:
+        return bytes([0x80]) + n.to_bytes(4, 'big')        # RDB_32BITLEN
+    else:
+        return bytes([0x81]) + n.to_bytes(8, 'big')        # RDB_64BITLEN
+
+
+# RDB_TYPE_MODULE_2 frames each saved value with a module opcode so it can be parsed
+# without the module loaded. ValkeyModule_SaveUnsigned emits: opcode + length.
+RDB_MODULE_OPCODE_EOF = 0
+RDB_MODULE_OPCODE_UINT = 2
+
+# JSON encver-0 metacodes (see meta_codes in dom.cc), each framed with OPCODE_UINT.
+JSON_METACODE_NULL = 0x01
+JSON_METACODE_STRING = 0x02
+JSON_METACODE_ARRAY = 0x40
+
+
+RDB_MODULE_OPCODE_STRING = 5
+
+
+def module_save_unsigned(n):
+    """Encode ValkeyModule_SaveUnsigned: opcode + length."""
+    return rdb_save_len(RDB_MODULE_OPCODE_UINT) + rdb_save_len(n)
+
+
+def module_save_string_buffer(data):
+    """Encode ValkeyModule_SaveStringBuffer: opcode + len + data."""
+    return rdb_save_len(RDB_MODULE_OPCODE_STRING) + rdb_save_len(len(data)) + data
+
 
 class TestRdb(JsonTestCase):
 
@@ -56,3 +129,96 @@ class TestRdb(JsonTestCase):
         assert True == client.execute_command('save')
         client.execute_command('FLUSHDB')
         assert b'OK' == client.execute_command('DEBUG', 'RELOAD', 'NOSAVE')
+
+    def test_rdb_restore_legacy_array_oom_bounded(self):
+        """
+        Regression test for issue #107: legacy RDB load passed an untrusted array count
+        directly to Reserve() and looped without IO-error checks, enabling OOM via RESTORE.
+        The fix caps pre-reservation and breaks on the first error.
+        """
+        import valkey
+        client = self.server.get_new_client()
+
+        # Self-check: CRC-64 matches the known test vector.
+        assert crc64(b"123456789") == 0xe9c6d914c4b8d9ca
+
+        # Extract module id and RDB version from a genuine DUMP.
+        assert b'OK' == client.execute_command('JSON.SET', 'arr', '.', '[1,2,3]')
+        genuine = bytes(client.execute_command('DUMP', 'arr'))
+
+        # Verify our CRC matches the server's footer.
+        assert crc64(genuine[:-8]) == int.from_bytes(genuine[-8:], 'little')
+        assert genuine[0] == 7, f"unexpected RDB type byte {genuine[0]:#x}"
+        assert genuine[1] == 0x81, f"unexpected module-id length encoding {genuine[1]:#x}"
+        module_id = int.from_bytes(genuine[2:10], 'big')
+        assert (module_id & 0x3FF) == 3, f"expected genuine encver 3, got {module_id & 0x3FF}"
+        rdbver_bytes = genuine[-10:-8]
+
+        # Downgrade encver to 0 to route through the legacy loader.
+        legacy_id_bytes = bytes([0x81]) + (module_id & ~0x3FF).to_bytes(8, 'big')
+
+        def make_restore_payload(body):
+            base = bytes([7]) + legacy_id_bytes + body + rdbver_bytes
+            return base + crc64(base).to_bytes(8, 'little')
+
+        # Positive case: a valid legacy array [null, null] must load correctly.
+        valid_body = (module_save_unsigned(JSON_METACODE_ARRAY)
+                      + module_save_unsigned(2)
+                      + module_save_unsigned(JSON_METACODE_NULL)
+                      + module_save_unsigned(JSON_METACODE_NULL)
+                      + rdb_save_len(RDB_MODULE_OPCODE_EOF))   # module value EOF marker
+        assert b'OK' == client.execute_command(
+            'RESTORE', 'legacy_ok', 0, make_restore_payload(valid_body))
+        assert b'[null,null]' == client.execute_command('JSON.GET', 'legacy_ok')
+
+        # Negative case: ~4 billion declared elements, no data. Pre-fix this OOM'd.
+        huge_body = (module_save_unsigned(JSON_METACODE_ARRAY)
+                     + module_save_unsigned((1 << 32) - 1))
+        evil_payload = make_restore_payload(huge_body)
+
+        # Short timeout as safety net if the bound regresses.
+        guarded = valkey.Valkey(host="localhost", port=self.server.port, socket_timeout=15)
+        with pytest.raises(ResponseError):
+            guarded.execute_command('RESTORE', 'evil', 0, evil_payload)
+
+        # Server must still be alive after rejecting the crafted payload.
+        assert client.execute_command('PING')
+        assert b'OK' == client.execute_command('JSON.SET', 'after', '.', '[1,2,3]')
+        assert b'[1,2,3]' == client.execute_command('JSON.GET', 'after')
+
+    def test_rdb_restore_legacy_array_truncated_element(self):
+        """
+        Safety-net: server survives a RESTORE with a truncated string element (EOF
+        mid-body). Passes on unfixed code too (core's stream-EOF catches it first),
+        but guards against regressions in that outer check.
+        """
+        import valkey
+        client = self.server.get_new_client()
+
+        # Get module id and rdbver from a genuine DUMP.
+        assert b'OK' == client.execute_command('JSON.SET', '_tmp', '.', '"x"')
+        genuine = bytes(client.execute_command('DUMP', '_tmp'))
+        client.execute_command('DEL', '_tmp')
+        module_id = int.from_bytes(genuine[2:10], 'big')
+        rdbver_bytes = genuine[-10:-8]
+        legacy_id_bytes = bytes([0x81]) + (module_id & ~0x3FF).to_bytes(8, 'big')
+
+        def make_restore_payload(body):
+            base = bytes([7]) + legacy_id_bytes + body + rdbver_bytes
+            return base + crc64(base).to_bytes(8, 'little')
+
+        # Array with a truncated string element (declares 10 bytes, provides 3).
+        truncated_body = (module_save_unsigned(JSON_METACODE_ARRAY)
+                         + module_save_unsigned(2)
+                         + module_save_unsigned(JSON_METACODE_STRING)
+                         + rdb_save_len(RDB_MODULE_OPCODE_STRING)
+                         + rdb_save_len(10)    # declares 10 bytes of string data
+                         + b'abc')             # only 3 bytes -- EOF mid-string
+
+        payload = make_restore_payload(truncated_body)
+        guarded = valkey.Valkey(host="localhost", port=self.server.port, socket_timeout=15)
+        with pytest.raises(ResponseError):
+            guarded.execute_command('RESTORE', 'trunc', 0, payload)
+
+        # Server must remain alive.
+        assert client.execute_command('PING')


### PR DESCRIPTION
Fix for: #107

The legacy (encoding version 0) RDB load path read an attacker-controlled array element
count and passed it straight to rapidjson's `Reserve()` with no bound, so a crafted
RESTORE or replication payload could request a ~64GB allocation and OOM-kill the server.
This fix caps the pre-reservation at `JSON_RDB_ARRAY_RESERVE_CAP` (65536) using `std::min`.
Genuine elements beyond the cap still grow the array via `PushBack` as they are actually
read, so there is no amplification from a tiny count field. The load loop now also breaks on
IO/status errors and propagates `JSONUTIL_INVALID_RDB_FORMAT`, and a check at the `dom_load`
chokepoint rejects any truncated load (object member, scalar) at the module boundary instead
of accepting a partial document.

Tests: added cases in test_rdb.py. A huge-count array payload is now rejected gracefully and
the server stays alive (without this change it balloons past 11GB), a valid legacy array still
round-trips, and a truncated array element is handled without crashing.