### PR TITLE
Fix JSON.MSET duplicate-key crash

### DIFF
--- a/src/json/json.cc
+++ b/src/json/json.cc
@@ -278,7 +278,6 @@ STATIC JsonUtilCode parseSetCmdArgs(ValkeyModuleString **argv, const int argc, S
 
 typedef struct {
     ValkeyModuleString *key_str;    // Required
-    ValkeyModuleKey *key;
     const char *path;               // Required
     const char *json;               // Required
     size_t json_len;
@@ -307,11 +306,11 @@ STATIC JsonUtilCode parseAndValidateMSetCmdArgs(ValkeyModuleCtx *ctx, ValkeyModu
         MSetCmdArgs &current_arg = (*args_list)[i];
 
         current_arg.key_str = argv[i * 3 + 1];
-        current_arg.key = static_cast<ValkeyModuleKey*>(
+        ValkeyModuleKey *key = static_cast<ValkeyModuleKey*>(
             ValkeyModule_OpenKey(ctx, current_arg.key_str, VALKEYMODULE_READ | VALKEYMODULE_WRITE));
 
         // Handle key allocation failure
-        if (!current_arg.key) {
+        if (!key) {
             rc = JSONUTIL_KEY_OPEN_ERROR;
             return rc;
         }
@@ -320,9 +319,9 @@ STATIC JsonUtilCode parseAndValidateMSetCmdArgs(ValkeyModuleCtx *ctx, ValkeyModu
         current_arg.json = ValkeyModule_StringPtrLen(argv[i * 3 + 3], &current_arg.json_len);
 
         // Validate key type
-        int type = ValkeyModule_KeyType(current_arg.key);
+        int type = ValkeyModule_KeyType(key);
         if (type != VALKEYMODULE_KEYTYPE_EMPTY &&
-            ValkeyModule_ModuleTypeGetType(current_arg.key) != DocumentType) {
+            ValkeyModule_ModuleTypeGetType(key) != DocumentType) {
             rc = JSONUTIL_NOT_A_DOCUMENT_KEY;
             return rc;
         }
@@ -354,7 +353,7 @@ STATIC JsonUtilCode parseAndValidateMSetCmdArgs(ValkeyModuleCtx *ctx, ValkeyModu
             }
             dom_free_doc(doc);
         } else {
-            JDocument *doc = static_cast<JDocument*>(ValkeyModule_ModuleTypeGetValue(current_arg.key));
+            JDocument *doc = static_cast<JDocument*>(ValkeyModule_ModuleTypeGetValue(key));
             if (!doc) {
                 rc = JSONUTIL_DOCUMENT_KEY_NOT_FOUND;
                 return rc;
@@ -735,6 +734,11 @@ int Command_JsonSet(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
     return ValkeyModule_ReplyWithSimpleString(ctx, "OK");
 }
 
+// JSON.MSET applies each key/path/value independently on a best-effort basis.
+// An op that no longer applies against the current document (for example because
+// an earlier op in the same command changed the document's shape) is skipped;
+// All applicable ops are applied and the command returns OK.
+// Replicate the command so replicas and the AOF apply the same best-effort result.
 int Command_JsonMSet(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
     ValkeyModule_AutoMemory(ctx);
 
@@ -749,44 +753,51 @@ int Command_JsonMSet(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) 
             return ValkeyModule_ReplyWithError(ctx, jsonutil_code_to_message(rc));
     }
 
-    // Apply changes
-    size_t i;
-    for (i = 0; i < num_keys; i++) {
-        // begin tracking memory
+    for (size_t i = 0; i < num_keys; i++) {
         int64_t begin_val = jsonstats_begin_track_mem();
 
-        if (args_list[i].is_root_path) { // Root document
-            // parse incoming JSON string
+        // Open the key fresh so each op sees the current value, even for duplicate keys
+        // where an earlier op may have replaced the document.
+        ValkeyModuleKey *key = static_cast<ValkeyModuleKey*>(
+            ValkeyModule_OpenKey(ctx, args_list[i].key_str, VALKEYMODULE_READ | VALKEYMODULE_WRITE));
+
+        if (args_list[i].is_root_path) {
             JDocument *doc;
             rc = dom_parse(ctx, args_list[i].json, args_list[i].json_len, &doc);
-            ValkeyModule_Assert(rc == JSONUTIL_SUCCESS);
+            if (rc != JSONUTIL_SUCCESS) {
+                jsonstats_end_track_mem(begin_val);
+                continue;  // skip this op
+            }
 
             int64_t delta = jsonstats_end_track_mem(begin_val);
             size_t doc_size = dom_get_doc_size(doc) + delta;
             dom_set_doc_size(doc, doc_size);
 
-            // Set Valkey key
-            ValkeyModule_ModuleTypeSetValue(args_list[i].key, DocumentType, doc);
-            // update stats
+            ValkeyModule_ModuleTypeSetValue(key, DocumentType, doc);
             jsonstats_update_stats_on_insert(doc, true, 0, doc_size, doc_size);
-        } else { // Update existing document
-            JDocument *doc = static_cast<JDocument*>(ValkeyModule_ModuleTypeGetValue(args_list[i].key));
+        } else {
+            JDocument *doc = static_cast<JDocument*>(ValkeyModule_ModuleTypeGetValue(key));
+            if (!doc) {
+                jsonstats_end_track_mem(begin_val);
+                continue;  // skip: key no longer holds a document
+            }
             size_t orig_doc_size = dom_get_doc_size(doc);
 
             rc = dom_set_value(ctx, doc, args_list[i].path, args_list[i].json, args_list[i].json_len, false, false);
-            ValkeyModule_Assert(rc == JSONUTIL_SUCCESS);
+            if (rc != JSONUTIL_SUCCESS) {
+                jsonstats_end_track_mem(begin_val);
+                continue;  // skip: path no longer valid against current document
+            }
             int64_t delta = jsonstats_end_track_mem(begin_val);
             size_t new_doc_size = dom_get_doc_size(doc) + delta;
             dom_set_doc_size(doc, new_doc_size);
 
-            // update stats
             jsonstats_update_stats_on_update(doc, orig_doc_size, new_doc_size, args_list[i].json_len);
         }
 
         ValkeyModule_NotifyKeyspaceEvent(ctx, VALKEYMODULE_NOTIFY_GENERIC, "json.mset", args_list[i].key_str);
     }
 
-    // replicate the entire command
     ValkeyModule_ReplicateVerbatim(ctx);
     ValkeyModule_Free(args_list);
     return ValkeyModule_ReplyWithSimpleString(ctx, "OK");

--- a/tst/integration/test_json_basic.py
+++ b/tst/integration/test_json_basic.py
@@ -2948,6 +2948,67 @@ class TestJsonBasic(JsonTestCase):
             assert value.encode() == client.execute_command(
                 'JSON.GET', key, path)
 
+    def test_json_mset_duplicate_key_root_then_path(self):
+        """Best-effort: root replace then conflicting path op on same key.
+        The root op applies, the path op is skipped (path no longer valid),
+        command returns OK, server stays alive."""
+        client = self.server.get_new_client()
+        dk = 'dk'
+        client.execute_command('JSON.SET', dk, '$', '{"a":1}')
+        # Op1 replaces root with array, op2 references .a which no longer exists
+        assert b'OK' == client.execute_command('JSON.MSET', dk, '$', '[1,2,3]', dk, '.a', '99')
+        # Server alive
+        assert client.execute_command('PING')
+        # Op1 applied, op2 skipped
+        assert b'[1,2,3]' == client.execute_command('JSON.GET', dk, '.')
+
+    def test_json_mset_duplicate_key_nested_path(self):
+        """Best-effort: nested object replacement then deeper path on same key.
+        First op applies, second is skipped (path no longer valid),
+        command returns OK."""
+        client = self.server.get_new_client()
+        dk = 'dk'
+        client.execute_command('JSON.SET', dk, '$', '{"a":{"x":1}}')
+        # Op1 replaces .a with array, op2 references .a.x which no longer exists
+        assert b'OK' == client.execute_command('JSON.MSET', dk, '.a', '[9]', dk, '.a.x', '5')
+        assert client.execute_command('PING')
+        # Op1 applied, op2 skipped
+        assert b'[9]' == client.execute_command('JSON.GET', dk, '.a')
+
+    def test_json_mset_duplicate_key_3ops_best_effort(self):
+        """Best-effort continues past conflicts: op1 ok, op2 conflicts, op3 ok.
+        A conflicting op is skipped and the remaining ops are still applied."""
+        client = self.server.get_new_client()
+        dk = 'dk'
+        k = 'mset3opk'
+        client.execute_command('JSON.SET', dk, '$', '{"a":1}')
+        client.execute_command('JSON.SET', k, '$', '{"v":0}')
+        # Op1: replace dk root (ok)
+        # Op2: set dk .a (conflicts - path gone after op1, skipped)
+        # Op3: update k .v (applied - best-effort continues past op2)
+        assert b'OK' == client.execute_command('JSON.MSET',
+                                              dk, '$', '[1,2,3]',
+                                              dk, '.a', '99',
+                                              k, '.v', '42')
+        assert client.execute_command('PING')
+        # Op1 applied
+        assert b'[1,2,3]' == client.execute_command('JSON.GET', dk, '.')
+        # Op3 applied (best-effort continues past conflict)
+        assert b'{"v":42}' == client.execute_command('JSON.GET', k, '.')
+
+    def test_json_mset_duplicate_key_later_op_valid(self):
+        """Duplicate key where the later op IS valid against the earlier op's result.
+        Op1 replaces root with {"b":1}, op2 sets .b to 2 on the new doc.
+        Both ops apply because each iteration opens the key fresh."""
+        client = self.server.get_new_client()
+        dk = 'dk'
+        client.execute_command('JSON.SET', dk, '$', '{"a":1}')
+        # Op1 replaces root, op2 sets .b on the NEW root — valid composition
+        assert b'OK' == client.execute_command('JSON.MSET', dk, '$', '{"b":1}', dk, '.b', '2')
+        assert client.execute_command('PING')
+        # Both ops applied: op1 set {"b":1}, op2 updated .b to 2
+        assert b'{"b":2}' == client.execute_command('JSON.GET', dk, '.')
+
     def test_multi_exec(self):
         client = self.server.get_new_client()
         client.execute_command('MULTI')


### PR DESCRIPTION
Fix for: #106

A `JSON.MSET` that references the same key more than once could crash the server
(SIGABRT). Triples are validated up front and then applied in place under
`ValkeyModule_Assert(rc == JSONUTIL_SUCCESS)`. For a duplicated key, an earlier op changes
the document's shape, so a later op (validated against the original shape) fails at apply
time and the assertion aborts the process.

This removes the apply-phase assertions and applies ops on a best-effort basis. Each key
is opened fresh at apply time, so every op sees the current value, including the effect of
an earlier op on the same key. An op that cannot apply against the current document is
skipped and the remaining ops are still applied; the command returns OK. Up-front
validation is unchanged, so malformed commands are still rejected atomically with an error
before any write.

This also makes JSON.MSET behavior compatible with RedisJSON.

Tests: added cases for a duplicated key whose later op conflicts with the first (returns
OK, server alive, first op committed), a three-op case where a middle op is skipped and
the others applied, and a case where the later op is valid against the first op's result
so both apply. Existing MSET and validation tests pass unchanged; the full integration
suite passes across all server versions including the ASAN build.