### PR TITLE
Making it so ASAN failures fail on CI, fixing heap-use-after-free bugs in JSON.MSET by closing key handles (ValkeyModule_CloseKey) in all code paths within the operation loop

### DIFF
--- a/src/json/json.cc
+++ b/src/json/json.cc
@@ -368,6 +368,8 @@ STATIC JsonUtilCode parseAndValidateMSetCmdArgs(ValkeyModuleCtx *ctx, ValkeyModu
                 return rc;
             }
         }
+        // Close the validation handle so no stale handle to a duplicate key survives.
+        ValkeyModule_CloseKey(key);
     }
     return JSONUTIL_SUCCESS;
 }
@@ -771,6 +773,7 @@ int Command_JsonMSet(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) 
             rc = dom_parse(ctx, args_list[i].json, args_list[i].json_len, &doc);
             if (rc != JSONUTIL_SUCCESS) {
                 jsonstats_end_track_mem(begin_val);
+                ValkeyModule_CloseKey(key);
                 continue;  // skip this op
             }
 
@@ -784,6 +787,7 @@ int Command_JsonMSet(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) 
             JDocument *doc = static_cast<JDocument*>(ValkeyModule_ModuleTypeGetValue(key));
             if (!doc) {
                 jsonstats_end_track_mem(begin_val);
+                ValkeyModule_CloseKey(key);
                 continue;  // skip: key no longer holds a document
             }
             size_t orig_doc_size = dom_get_doc_size(doc);
@@ -791,6 +795,7 @@ int Command_JsonMSet(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) 
             rc = dom_set_value(ctx, doc, args_list[i].path, args_list[i].json, args_list[i].json_len, false, false);
             if (rc != JSONUTIL_SUCCESS) {
                 jsonstats_end_track_mem(begin_val);
+                ValkeyModule_CloseKey(key);
                 continue;  // skip: path no longer valid against current document
             }
             int64_t delta = jsonstats_end_track_mem(begin_val);
@@ -801,6 +806,9 @@ int Command_JsonMSet(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) 
         }
 
         ValkeyModule_NotifyKeyspaceEvent(ctx, VALKEYMODULE_NOTIFY_GENERIC, "json.mset", args_list[i].key_str);
+        // Close before the next op reopens this key; duplicate keys free the doc/key
+        // object, and a lingering handle would dangle at teardown (heap-use-after-free).
+        ValkeyModule_CloseKey(key);
     }
 
     ValkeyModule_ReplicateVerbatim(ctx);

--- a/tst/integration/run.sh
+++ b/tst/integration/run.sh
@@ -27,28 +27,64 @@ fi
 
 if [[ $1 == "test" ]] ; then
     if [ ! -z "${ASAN_BUILD}" ]; then
-        echo "Running tests and checking for memory leaks"
+        echo "Running tests with AddressSanitizer enabled"
+
+        # Make ASAN/LSAN report reliably. Reports go to stderr detect_leaks=1 enables 
+        # leak checks at process exit. We do not abort the process so pytest can finish;
+        # any error is caught via the log scan and the pytest exit code below.
+        export ASAN_OPTIONS="detect_leaks=1:halt_on_error=0:abort_on_error=0:log_path=stderr${ASAN_OPTIONS:+:${ASAN_OPTIONS}}"
+
+        # Propagate the real pytest exit status through the pipe to tee.
+        set -o pipefail
         python -m pytest --capture=sys --html=report.html --cache-clear -v ${TEST_FLAG} ./ ${TEST_PATTERN} 2>&1 | tee test_output.tmp
-        # Check for memory leaks in the output
+        PYTEST_STATUS=${PIPESTATUS[0]}
+        set +o pipefail
+
+        RED='\033[0;31m'
+        NC='\033[0m'
+        FAILED=0
+
+        # 1) Any AddressSanitizer error: heap-buffer-overflow, heap-use-after-free,
+        #    stack/global-buffer-overflow, etc.
+        if grep -Eq "(ERROR|WARNING): AddressSanitizer:|SUMMARY: AddressSanitizer:" test_output.tmp; then
+            echo -e "${RED}AddressSanitizer reported errors:${NC}"
+            grep -nE "(ERROR|WARNING): AddressSanitizer:|SUMMARY: AddressSanitizer:" test_output.tmp | \
+            while read -r line; do
+                echo "::error::ASAN: ${line}"
+            done
+            FAILED=1
+        fi
+
+        # 2) Memory leaks reported by LeakSanitizer.
         if grep -q "LeakSanitizer: detected memory leaks" test_output.tmp; then
-            RED='\033[0;31m'
-            echo -e "${RED}Memory leaks detected in the following tests:"
+            echo -e "${RED}Memory leaks detected in the following tests:${NC}"
             LEAKING_TESTS=$(grep -B 2 "LeakSanitizer: detected memory leaks" test_output.tmp | \
                             grep -v "LeakSanitizer" | \
                             grep ".*\.py::")
-            
-            LEAK_COUNT=$(echo "$LEAKING_TESTS" | wc -l)
-            
+
+            LEAK_COUNT=$(echo "$LEAKING_TESTS" | grep -c .)
+
             # Output each leaking test
             echo "$LEAKING_TESTS" | while read -r line; do
-                echo "::error::Test with leak: $line"
+                [ -n "$line" ] && echo "::error::Test with leak: ${line}"
             done
-            
-            echo -e "\n$LEAK_COUNT python integration tests have leaks detected in them"
-            rm test_output.tmp
+
+            echo -e "\n${LEAK_COUNT} python integration tests have leaks detected in them"
+            FAILED=1
+        fi
+
+        # 3) pytest itself failed (assertion failure, or a server crash caused by a
+        #    fatal ASAN error that terminated the process mid-test).
+        if [ "${PYTEST_STATUS}" -ne 0 ]; then
+            echo -e "${RED}pytest exited with status ${PYTEST_STATUS}${NC}"
+            echo "::error::pytest exited with status ${PYTEST_STATUS}"
+            FAILED=1
+        fi
+
+        rm -f test_output.tmp
+        if [ "${FAILED}" -ne 0 ]; then
             exit 1
         fi
-        rm test_output.tmp
     else
         python -m pytest --html=report.html --cache-clear -v ${TEST_FLAG} ./ ${TEST_PATTERN}
     fi


### PR DESCRIPTION
JSON.MSET opened key handles in both the parse/validation loop and the apply loop but never closed them, relying on AutoMemory to clean up at command end.

For duplicate keys, a later op's ValkeyModule_ModuleTypeSetValue does a VM_DeleteKey + re-add, freeing the key object that an earlier still-open handle points at. AutoMemory then closes that stale handle at command teardown -> heap-use-after-free (ASAN: moduleCloseKey, module.c:4456).

Fix: ValkeyModule_CloseKey each handle as soon as it is no longer needed (after validation in the parse loop, and at the end of every apply-loop iteration including the skip/continue paths), so at most one live handle exists per key.

Reproduced and verified under ASAN (amztests-asan) on the exact failing tests. This also exposed that ASAN failures were not being caught properly in the CI runs. This PR also fixes this but still allows the full suite of tests to run and check for failures and show as a fail at the end.

Example run of failing: https://github.com/zackcam/valkey-json/actions/runs/27984788018/job/82823547063 this was a run with the new CI changes but missing the MSET fixes and we can see it failed on ASAN.


