### PR TITLE
Making PR's run unstable and latest only, adding a daily job for all versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,48 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  # All versions run at 06:00 UTC every day (full backwards-compat matrix).
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
 
 jobs:
+  get-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.discover.outputs.versions }}
+    steps:
+      - name: Discover valkey server versions
+        id: discover
+        env:
+          VALKEY_REPO_URL: https://github.com/valkey-io/valkey.git
+          MIN_SERVER_MAJOR: '8'
+        run: |
+          branches=$(git ls-remote --heads "$VALKEY_REPO_URL" \
+            | sed 's#.*refs/heads/##' \
+            | grep -E '^[0-9]+\.[0-9]+$' \
+            | awk -F. -v M="$MIN_SERVER_MAJOR" '$1>=M' \
+            | sort -V)
+          # PRs/pushes: fast signal — only "unstable" + the latest official release.
+          # schedule/workflow_dispatch: full supported matrix for backwards-compat.
+          if [ "$GITHUB_EVENT_NAME" = "schedule" ] || [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            selected="$branches"
+          else
+            selected=$(printf '%s\n' $branches | tail -n 1)
+          fi
+          json=$(printf '%s\n' unstable $selected | jq -R . | jq -sc .)
+          echo "Event: $GITHUB_EVENT_NAME -> versions: $json"
+          echo "versions=$json" >> "$GITHUB_OUTPUT"
+
   build-release:
+    needs: get-versions
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        server_version: ['unstable', '8.0', '8.1', '9.0']
+        server_version: ${{ fromJSON(needs.get-versions.outputs.versions) }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Set the server version
@@ -17,11 +51,12 @@ jobs:
         run: ./build.sh
 
   unit-tests:
+    needs: get-versions
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        server_version: ['unstable', '8.0', '8.1', '9.0']
+        server_version: ${{ fromJSON(needs.get-versions.outputs.versions) }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Set the server version
@@ -30,11 +65,12 @@ jobs:
         run: ./build.sh --unit
 
   integration-tests:
+    needs: get-versions
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        server_version: ['unstable', '8.0', '8.1', '9.0']
+        server_version: ${{ fromJSON(needs.get-versions.outputs.versions) }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Set the server version
@@ -51,11 +87,12 @@ jobs:
         run: ./build.sh --integration
 
   asan-tests:
+    needs: get-versions
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        server_version: ['unstable', '8.0', '8.1', '9.0']
+        server_version: ${{ fromJSON(needs.get-versions.outputs.versions) }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Set the server version

--- a/build.sh
+++ b/build.sh
@@ -81,14 +81,21 @@ fi
 
 REPO_URL="https://github.com/valkey-io/valkey.git"
 MIN_SERVER_MAJOR="8"
-VALID_VERSIONS=$(printf 'unstable\n%s\n' "$(git ls-remote --heads "$REPO_URL" \
-  | sed 's#.*refs/heads/##' \
-  | grep -E '^[0-9]+\.[0-9]+$' \
-  | awk -F. -v M="$MIN_SERVER_MAJOR" '$1>=M')")
-if ! printf '%s\n' "$VALID_VERSIONS" | grep -qxF "$SERVER_VERSION"; then
-  echo "ERROR: Unsupported version - $SERVER_VERSION"
-  echo "Valid versions are: $(printf '%s\n' "$VALID_VERSIONS" | sort -V | tr '\n' ' ')"
-  exit 1
+
+if ! REMOTE_REFS=$(git ls-remote --heads "$REPO_URL" 2>/dev/null); then
+  echo "WARNING: could not reach $REPO_URL to validate SERVER_VERSION; skipping version check" >&2
+else
+  RELEASE_VERSIONS=$(printf '%s\n' "$REMOTE_REFS" \
+    | sed 's#.*refs/heads/##' \
+    | grep -E '^[0-9]+\.[0-9]+$' \
+    | awk -F. -v M="$MIN_SERVER_MAJOR" '$1>=M' \
+    | sort -V)
+  VALID_VERSIONS=$(printf 'unstable\n%s\n' "$RELEASE_VERSIONS")
+  if ! printf '%s\n' "$VALID_VERSIONS" | grep -qxF "$SERVER_VERSION"; then
+    echo "ERROR: Unsupported version - $SERVER_VERSION"
+    echo "Valid versions are: $(printf '%s\n' "$VALID_VERSIONS" | sort -V | tr '\n' ' ')"
+    exit 1
+  fi
 fi
 
 mkdir -p "$BUILD_DIR"

--- a/build.sh
+++ b/build.sh
@@ -79,6 +79,18 @@ if [ -z "$SERVER_VERSION" ]; then
     export SERVER_VERSION="unstable"
 fi
 
+REPO_URL="https://github.com/valkey-io/valkey.git"
+MIN_SERVER_MAJOR="8"
+VALID_VERSIONS=$(printf 'unstable\n%s\n' "$(git ls-remote --heads "$REPO_URL" \
+  | sed 's#.*refs/heads/##' \
+  | grep -E '^[0-9]+\.[0-9]+$' \
+  | awk -F. -v M="$MIN_SERVER_MAJOR" '$1>=M')")
+if ! printf '%s\n' "$VALID_VERSIONS" | grep -qxF "$SERVER_VERSION"; then
+  echo "ERROR: Unsupported version - $SERVER_VERSION"
+  echo "Valid versions are: $(printf '%s\n' "$VALID_VERSIONS" | sort -V | tr '\n' ' ')"
+  exit 1
+fi
+
 mkdir -p "$BUILD_DIR"
 cd "$BUILD_DIR"
 


### PR DESCRIPTION
This pr has set up a daily job to run JSON against all versions of valkey (If this becomes unwieldily we can easily amend to limit number of versions). In addition it now will run pr requests only against unstable and the latest version which is got dynamically so will not need to be updated on releases. The build script also now contains a dynamic way of checking and asserting what versions are availble