### PR TITLE
Backport and Release notes 1.0.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,48 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  # All versions run at 06:00 UTC every day (full backwards-compat matrix).
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
 
 jobs:
+  get-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.discover.outputs.versions }}
+    steps:
+      - name: Discover valkey server versions
+        id: discover
+        env:
+          VALKEY_REPO_URL: https://github.com/valkey-io/valkey.git
+          MIN_SERVER_MAJOR: '8'
+        run: |
+          branches=$(git ls-remote --heads "$VALKEY_REPO_URL" \
+            | sed 's#.*refs/heads/##' \
+            | grep -E '^[0-9]+\.[0-9]+$' \
+            | awk -F. -v M="$MIN_SERVER_MAJOR" '$1>=M' \
+            | sort -V)
+          # PRs/pushes: fast signal — only "unstable" + the latest official release.
+          # schedule/workflow_dispatch: full supported matrix for backwards-compat.
+          if [ "$GITHUB_EVENT_NAME" = "schedule" ] || [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            selected="$branches"
+          else
+            selected=$(printf '%s\n' $branches | tail -n 1)
+          fi
+          json=$(printf '%s\n' unstable $selected | jq -R . | jq -sc .)
+          echo "Event: $GITHUB_EVENT_NAME -> versions: $json"
+          echo "versions=$json" >> "$GITHUB_OUTPUT"
+
   build-release:
+    needs: get-versions
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        server_version: ['unstable', '8.0', '8.1', '9.0']
+        server_version: ${{ fromJSON(needs.get-versions.outputs.versions) }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Set the server version
@@ -17,11 +51,12 @@ jobs:
         run: ./build.sh
 
   unit-tests:
+    needs: get-versions
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        server_version: ['unstable', '8.0', '8.1', '9.0']
+        server_version: ${{ fromJSON(needs.get-versions.outputs.versions) }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Set the server version
@@ -30,11 +65,12 @@ jobs:
         run: ./build.sh --unit
 
   integration-tests:
+    needs: get-versions
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        server_version: ['unstable', '8.0', '8.1', '9.0']
+        server_version: ${{ fromJSON(needs.get-versions.outputs.versions) }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Set the server version
@@ -51,11 +87,12 @@ jobs:
         run: ./build.sh --integration
 
   asan-tests:
+    needs: get-versions
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        server_version: ['unstable', '8.0', '8.1', '9.0']
+        server_version: ${{ fromJSON(needs.get-versions.outputs.versions) }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Set the server version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:
@@ -25,13 +28,18 @@ jobs:
             | grep -E '^[0-9]+\.[0-9]+$' \
             | awk -F. -v M="$MIN_SERVER_MAJOR" '$1>=M' \
             | sort -V)
-          # PRs/pushes: fast signal — only "unstable" + the latest official release.
-          # schedule/workflow_dispatch: full supported matrix for backwards-compat.
-          if [ "$GITHUB_EVENT_NAME" = "schedule" ] || [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
-            selected="$branches"
-          else
-            selected=$(printf '%s\n' $branches | tail -n 1)
-          fi
+          target="${GITHUB_BASE_REF:-$GITHUB_REF_NAME}"
+          case "$GITHUB_EVENT_NAME" in
+            schedule|workflow_dispatch) selected="$branches" ;;
+            *)
+              if [ "$target" = "unstable" ]; then
+                selected=$(printf '%s\n' $branches | tail -n 1)
+              else
+                selected="$branches"
+              fi
+              ;;
+          esac
+          echo "valkey-json branch under test: $target"
           json=$(printf '%s\n' unstable $selected | jq -R . | jq -sc .)
           echo "Event: $GITHUB_EVENT_NAME -> versions: $json"
           echo "versions=$json" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,35 @@
+name: Linter
+
+on:
+  push:
+  pull_request:
+
+concurrency:
+  group: linter-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  cpplint:
+    name: C++ Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Set up Python
+        uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3.1.4
+        with:
+          python-version: '3.9'
+
+      - name: Install cpplint
+        run: pip install cpplint
+
+      - name: Run cpplint on src/json
+        run: cpplint --recursive src/json/
+
+      - name: Run cpplint on tst/unit
+        run: cpplint --recursive tst/unit/

--- a/00-RELEASENOTES
+++ b/00-RELEASENOTES
@@ -1,5 +1,38 @@
 Valkey JSON 1.0 release notes
 ========================
+
+Upgrade urgency levels:
+
+| Level    | Meaning                                                             |
+|----------|---------------------------------------------------------------------|
+| LOW      | No need to upgrade unless there are new features you want to use.   |
+| MODERATE | Program an upgrade of the server, but it's not urgent.              |
+| HIGH     | There is a critical bug that may affect a subset of users. Upgrade! |
+| CRITICAL | There is a critical bug affecting MOST USERS. Upgrade ASAP.         |
+| SECURITY | There are security fixes in the release.                            |
+
+================================================================================
+Valkey JSON 1.0.3  -  Released Mon 31 August 2026
+================================================================================
+
+Upgrade urgency SECURITY: This release includes security fixes we recommend you
+apply as soon as possible.
+
+Security fixes
+==============
+* (GHSA-q7rf-74qm-hr9g) Fix use-after-free in recursive JSONPath mutations, affecting `JSON.ARRAPPEND`, `JSON.ARRINSERT`, `JSON.ARRPOP`, `JSON.ARRTRIM` and `JSON.CLEAR` by @zackcam (#120)
+
+Bug fixes
+=========
+* Fix crash when converting a stored number that is out of range for a double by @zackcam (#109)
+* Fix out-of-bounds read when a member name contains `~` by @zackcam (#108)
+* Fix crash in `JSON.MSET` when the same key is given more than once by @roshkhatri (#112)
+* Bound array pre-allocation on legacy RDB and `RESTORE` load, and reject truncated streams by @roshkhatri (#111)
+* Fix heap use-after-free in `JSON.MSET` caused by unclosed key handles by @zackcam (#116)
+* Restrict `JSON.DEBUG KEYTABLE-CORRUPT`, `KEYTABLE-CLEAR` and `KEYTABLE-DISTRIBUTION` to modules loaded with `json.debug-mode` by @roshkhatri (#98)
+* Set `VALKEYMODULE_OPTIONS_HANDLE_REPL_ASYNC_LOAD` to handle asynchronous replication load by @dmitrypol (#89)
+* Fix build failure on GCC 16 for a `maybe_unused` variable by @hanxizh9910 (#97)
+
 ================================================================================
 Valkey JSON 1.0.2 - Released Mon 8 September 2025
 ================================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,9 +89,49 @@ if(ENABLE_ASAN)
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${ASAN_FLAGS}")
 endif()
 
+# Optional: path to an externally built valkey-server binary. When set,
+# we skip building Valkey from source and copy the provided binary into
+# the integration test directory instead. The Valkey source is still
+# downloaded (without being built) so that valkeymodule.h can be copied,
+# unless VALKEY_MODULE_H_PATH is also provided (see below).
+set(VALKEY_SERVER_PATH "" CACHE STRING "Path to an externally built valkey-server binary; if set, skip building Valkey from source")
+
+# Optional: path to an external valkeymodule.h header. When set, the
+# header is copied from this path instead of from the cloned Valkey
+# source. Combined with VALKEY_SERVER_PATH (or a non-integration build),
+# this lets the build skip cloning the Valkey repo entirely, enabling
+# fully offline builds and exact header/binary version matching.
+set(VALKEY_MODULE_H_PATH "" CACHE STRING "Path to an external valkeymodule.h; combined with VALKEY_SERVER_PATH allows fully offline builds")
+
+if(VALKEY_SERVER_PATH)
+    if(NOT EXISTS "${VALKEY_SERVER_PATH}")
+        message(FATAL_ERROR "VALKEY_SERVER_PATH is set but file does not exist: ${VALKEY_SERVER_PATH}")
+    endif()
+    message(STATUS "Using external valkey-server binary: ${VALKEY_SERVER_PATH}")
+endif()
+
+if(VALKEY_MODULE_H_PATH)
+    if(NOT EXISTS "${VALKEY_MODULE_H_PATH}")
+        message(FATAL_ERROR "VALKEY_MODULE_H_PATH is set but file does not exist: ${VALKEY_MODULE_H_PATH}")
+    endif()
+    message(STATUS "Using external valkeymodule.h: ${VALKEY_MODULE_H_PATH}")
+endif()
+
+# Decide whether the Valkey source needs to be cloned. The clone serves
+# two purposes: providing valkeymodule.h, and providing the source tree
+# to build valkey-server for integration tests. If both can be satisfied
+# externally, skip the clone entirely.
+set(VALKEY_NEED_CLONE TRUE)
+if(VALKEY_MODULE_H_PATH AND (VALKEY_SERVER_PATH OR NOT ENABLE_INTEGRATION_TESTS))
+    set(VALKEY_NEED_CLONE FALSE)
+    message(STATUS "Offline build: skipping Valkey source clone")
+endif()
+
 # Determine Valkey build command depending on build type
 if((BUILD_RELEASE OR ENABLE_UNIT_TESTS) AND NOT ENABLE_INTEGRATION_TESTS)
     set(VALKEY_BUILD_CMD ${CMAKE_COMMAND} -E echo "Skipping build step for release build")
+elseif(VALKEY_SERVER_PATH)
+    set(VALKEY_BUILD_CMD ${CMAKE_COMMAND} -E echo "Skipping Valkey build (using external valkey-server: ${VALKEY_SERVER_PATH})")
 else()
     if(ENABLE_ASAN)
         set(VALKEY_BUILD_CMD make distclean && make -j SANITIZER=address)
@@ -100,41 +140,68 @@ else()
     endif()
 endif()
 
-ExternalProject_Add(
-    valkey
-    GIT_REPOSITORY https://github.com/valkey-io/valkey.git
-    GIT_TAG ${VALKEY_VERSION}
-    PREFIX ${VALKEY_DOWNLOAD_DIR}
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND ${VALKEY_BUILD_CMD}
-    INSTALL_COMMAND ""
-    BUILD_IN_SOURCE 1
-)
-
 # Define the paths for the copied files
 set(VALKEY_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/include")
 set(VALKEY_BINARY_DEST "${CMAKE_CURRENT_SOURCE_DIR}/tst/integration/.build/binaries/${VALKEY_VERSION}")
 
-ExternalProject_Add_Step(
-    valkey
-    copy_header_files
-    COMMENT "Copying header files to include/ directory"
-    DEPENDEES download
-    DEPENDERS configure
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${VALKEY_INCLUDE_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy ${VALKEY_DOWNLOAD_DIR}/src/valkey/src/valkeymodule.h ${VALKEY_INCLUDE_DIR}/valkeymodule.h
-    ALWAYS 1
-)
+if(VALKEY_NEED_CLONE)
+    ExternalProject_Add(
+        valkey
+        GIT_REPOSITORY https://github.com/valkey-io/valkey.git
+        GIT_TAG ${VALKEY_VERSION}
+        PREFIX ${VALKEY_DOWNLOAD_DIR}
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ${VALKEY_BUILD_CMD}
+        INSTALL_COMMAND ""
+        BUILD_IN_SOURCE 1
+    )
+
+    # Header source: prefer the user-provided path; otherwise use the
+    # one from the cloned Valkey repo.
+    if(VALKEY_MODULE_H_PATH)
+        set(VALKEY_MODULE_H_SRC "${VALKEY_MODULE_H_PATH}")
+    else()
+        set(VALKEY_MODULE_H_SRC "${VALKEY_DOWNLOAD_DIR}/src/valkey/src/valkeymodule.h")
+    endif()
+
+    ExternalProject_Add_Step(
+        valkey
+        copy_header_files
+        COMMENT "Copying header files to include/ directory"
+        DEPENDEES download
+        DEPENDERS configure
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${VALKEY_INCLUDE_DIR}
+        COMMAND ${CMAKE_COMMAND} -E copy ${VALKEY_MODULE_H_SRC} ${VALKEY_INCLUDE_DIR}/valkeymodule.h
+        ALWAYS 1
+    )
+else()
+    # Fully offline build: both valkey-server (if needed) and
+    # valkeymodule.h are provided by the user, so we don't clone the
+    # Valkey repo at all. Provide a placeholder utility target named
+    # "valkey" so existing dependants (add_dependencies / POST_BUILD
+    # custom_command) keep working unchanged.
+    add_custom_target(valkey
+        COMMAND ${CMAKE_COMMAND} -E echo "Offline build: skipping Valkey clone/build"
+    )
+    file(MAKE_DIRECTORY ${VALKEY_INCLUDE_DIR})
+    configure_file(${VALKEY_MODULE_H_PATH} ${VALKEY_INCLUDE_DIR}/valkeymodule.h COPYONLY)
+endif()
 
 # Integration tests require the valkey-test-framework which is only needed when
 # building Valkey from source.
 if(ENABLE_INTEGRATION_TESTS)
-    # Copy the valkey-server binary after building
+    if(VALKEY_SERVER_PATH)
+        set(VALKEY_SERVER_SRC "${VALKEY_SERVER_PATH}")
+    else()
+        set(VALKEY_SERVER_SRC "${VALKEY_BIN_DIR}/valkey-server")
+    endif()
+    # Copy the valkey-server binary after building (or after the no-op
+    # build step when VALKEY_SERVER_PATH is provided)
     add_custom_command(TARGET valkey
             POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E make_directory ${VALKEY_BINARY_DEST}
-            COMMAND ${CMAKE_COMMAND} -E copy ${VALKEY_BIN_DIR}/valkey-server ${VALKEY_BINARY_DEST}/valkey-server
-            COMMENT "Copied valkey-server to destination directory"
+            COMMAND ${CMAKE_COMMAND} -E copy ${VALKEY_SERVER_SRC} ${VALKEY_BINARY_DEST}/valkey-server
+            COMMENT "Copied valkey-server (${VALKEY_SERVER_SRC}) to destination directory"
         )
     # Define valkey-test-framework commit id
     set(VALKEY_TEST_FRAMEWORK_COMMIT "33cc62660ea94d49bd6ab27cb8c09b345fc5d577" CACHE STRING "Valkey-test-framework commit to use")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,7 @@ if(ENABLE_INTEGRATION_TESTS)
             COMMENT "Copied valkey-server to destination directory"
         )
     # Define valkey-test-framework commit id
-    set(VALKEY_TEST_FRAMEWORK_COMMIT "9fb28b74efd122324db00498a2fde6e5d281c90f" CACHE STRING "Valkey-test-framework commit to use")
+    set(VALKEY_TEST_FRAMEWORK_COMMIT "33cc62660ea94d49bd6ab27cb8c09b345fc5d577" CACHE STRING "Valkey-test-framework commit to use")
 
     # Set the download directory for Valkey-test-framework
     set(VALKEY_TEST_FRAMEWORK_DOWNLOAD_DIR "${CMAKE_CURRENT_BINARY_DIR}/_deps/valkey-test-framework-src")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ else()
 endif()
 
 # Project definition
-project(ValkeyJSONModule VERSION 1.0.2 LANGUAGES C CXX)
+project(ValkeyJSONModule VERSION 1.0.3 LANGUAGES C CXX)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-mismatched-tags -Wno-format")
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ export ASAN_BUILD=true
 ./build.sh --integration
 ```
 
+By default, integration tests launch a local Valkey server.
+To run them against an external Valkey server instead (with the JSON module already loaded), set `VALKEY_EXTERNAL_SERVER=true`.
+The host and port can be customized via `VALKEY_HOST` (default `localhost`) and `VALKEY_PORT` (default `6379`):
+```text
+VALKEY_EXTERNAL_SERVER=true VALKEY_HOST=127.0.0.1 VALKEY_PORT=6379 ./build.sh --integration
+```
+
 ## Cleaning
 ```text
 # Clean build artifacts

--- a/README.md
+++ b/README.md
@@ -78,6 +78,44 @@ valkey-server --loadmodule /path/to/libjson.so
 2. Execute Valkey command:
     MODULE LOAD /path/to/libjson.so
 ```
+
+## Configuration
+
+### Document path limit (`json.max-path-limit`)
+
+JSON documents are subject to a **maximum nesting depth** (path limit). This limit caps how deeply objects and arrays can be nested (e.g. `a.b.c.d...`). It is used to avoid unbounded recursion and stack overflow when parsing, merging, or traversing documents.
+
+- **Config key:** `json.max-path-limit`
+- **Default:** 128
+- **Range:** 0 to INT_MAX
+
+If an operation would create or load a document whose nesting depth exceeds this limit, the module returns an error: *"Document path nesting limit is exceeded"*. The same limit is enforced when merging values (e.g. with `JSON.MERGE` or merge semantics in `JSON.SET`): once the recursion depth reaches the limit, merging stops and the new value is used as-is for the remainder of the path.
+
+To change the limit (e.g. to 256):
+
+```text
+CONFIG SET json.max-path-limit 256
+```
+
+### Debug commands (`json.debug-mode`)
+
+The `JSON.DEBUG KEYTABLE-CORRUPT`, `JSON.DEBUG KEYTABLE-CLEAR`, and `JSON.DEBUG KEYTABLE-DISTRIBUTION` subcommands are intended for development and debugging only. They are gated behind the `json.debug-mode` hidden module config, which is **immutable** — it can only be set at module load time.
+
+To enable debug commands, load the module and set the config via Valkey's CLI or config file:
+
+```text
+valkey-server --loadmodule /path/to/libjson.so --json.debug-mode yes
+```
+
+Or in `valkey.conf`:
+
+```text
+loadmodule /path/to/libjson.so
+json.debug-mode yes
+```
+
+When `debug-mode` is not enabled (the default), these subcommands return an error.
+
 ## Supported  Module Commands
 ```text
 JSON.ARRAPPEND

--- a/README.md
+++ b/README.md
@@ -49,6 +49,22 @@ To build the module with ASAN and run tests
 export ASAN_BUILD=true
 ./build.sh --integration
 ```
+To skip building Valkey from source and reuse an externally built `valkey-server` binary, set `VALKEY_SERVER_PATH` to its absolute path.
+The binary will be copied into the integration test directory; `valkeymodule.h` is still fetched from the Valkey repo for compiling the module:
+```text
+SERVER_VERSION=unstable \
+VALKEY_SERVER_PATH=/path/to/valkey-server \
+./build.sh --integration
+```
+
+To use a local `valkeymodule.h` (e.g. to match the exact version of the binary above, or to build offline), set `VALKEY_MODULE_H_PATH` to its absolute path.
+When both `VALKEY_SERVER_PATH` and `VALKEY_MODULE_H_PATH` are set, the Valkey repo is no longer cloned, enabling a fully offline build:
+```text
+SERVER_VERSION=unstable \
+VALKEY_SERVER_PATH=/path/to/valkey-server \
+VALKEY_MODULE_H_PATH=/path/to/valkeymodule.h \
+./build.sh --integration
+```
 
 By default, integration tests launch a local Valkey server.
 To run them against an external Valkey server instead (with the JSON module already loaded), set `VALKEY_EXTERNAL_SERVER=true`.

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ json.debug-mode yes
 
 When `debug-mode` is not enabled (the default), these subcommands return an error.
 
-## Supported  Module Commands
+## Supported Module Commands
 ```text
 JSON.ARRAPPEND
 JSON.ARRINDEX

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ JSON documents are subject to a **maximum nesting depth** (path limit). This lim
 - **Default:** 128
 - **Range:** 0 to INT_MAX
 
-If an operation would create or load a document whose nesting depth exceeds this limit, the module returns an error: *"Document path nesting limit is exceeded"*. The same limit is enforced when merging values (e.g. with `JSON.MERGE` or merge semantics in `JSON.SET`): once the recursion depth reaches the limit, merging stops and the new value is used as-is for the remainder of the path.
+If an operation would create or load a document whose nesting depth exceeds this limit, the module returns an error: *"Document path nesting limit is exceeded"*. The same limit is enforced when merging values (e.g. with the merge semantics in `JSON.SET`): once the recursion depth reaches the limit, merging stops and the new value is used as-is for the remainder of the path.
 
 To change the limit (e.g. to 256):
 

--- a/build.sh
+++ b/build.sh
@@ -109,6 +109,24 @@ fi
 
 CMAKE_FLAGS="$CMAKE_FLAGS -DENABLE_UNIT_TESTS=${ENABLE_UNIT_TESTS} -DENABLE_INTEGRATION_TESTS=${ENABLE_INTEGRATION_TESTS} -DBUILD_RELEASE=${ENABLE_BUILD_RELEASE}"
 
+if [ -n "$VALKEY_SERVER_PATH" ]; then
+    if [ ! -f "$VALKEY_SERVER_PATH" ]; then
+        echo "Error: VALKEY_SERVER_PATH is set but file does not exist: $VALKEY_SERVER_PATH"
+        exit 1
+    fi
+    echo "Using external valkey-server binary: $VALKEY_SERVER_PATH"
+    CMAKE_FLAGS="$CMAKE_FLAGS -DVALKEY_SERVER_PATH=$VALKEY_SERVER_PATH"
+fi
+
+if [ -n "$VALKEY_MODULE_H_PATH" ]; then
+    if [ ! -f "$VALKEY_MODULE_H_PATH" ]; then
+        echo "Error: VALKEY_MODULE_H_PATH is set but file does not exist: $VALKEY_MODULE_H_PATH"
+        exit 1
+    fi
+    echo "Using external valkeymodule.h: $VALKEY_MODULE_H_PATH"
+    CMAKE_FLAGS="$CMAKE_FLAGS -DVALKEY_MODULE_H_PATH=$VALKEY_MODULE_H_PATH"
+fi
+
 if [ -z "${CFLAGS}" ]; then
     cmake .. -DVALKEY_VERSION=${SERVER_VERSION} ${CMAKE_FLAGS}
 else

--- a/build.sh
+++ b/build.sh
@@ -79,6 +79,25 @@ if [ -z "$SERVER_VERSION" ]; then
     export SERVER_VERSION="unstable"
 fi
 
+REPO_URL="https://github.com/valkey-io/valkey.git"
+MIN_SERVER_MAJOR="8"
+
+if ! REMOTE_REFS=$(git ls-remote --heads "$REPO_URL" 2>/dev/null); then
+  echo "WARNING: could not reach $REPO_URL to validate SERVER_VERSION; skipping version check" >&2
+else
+  RELEASE_VERSIONS=$(printf '%s\n' "$REMOTE_REFS" \
+    | sed 's#.*refs/heads/##' \
+    | grep -E '^[0-9]+\.[0-9]+$' \
+    | awk -F. -v M="$MIN_SERVER_MAJOR" '$1>=M' \
+    | sort -V)
+  VALID_VERSIONS=$(printf 'unstable\n%s\n' "$RELEASE_VERSIONS")
+  if ! printf '%s\n' "$VALID_VERSIONS" | grep -qxF "$SERVER_VERSION"; then
+    echo "ERROR: Unsupported version - $SERVER_VERSION"
+    echo "Valid versions are: $(printf '%s\n' "$VALID_VERSIONS" | sort -V | tr '\n' ' ')"
+    exit 1
+  fi
+fi
+
 mkdir -p "$BUILD_DIR"
 cd "$BUILD_DIR"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 valkey
-pytest==6
+pytest==7.4.3
 pytest-html
+setuptools

--- a/src/commands/json.debug.json
+++ b/src/commands/json.debug.json
@@ -1,6 +1,6 @@
 {
     "JSON.DEBUG": {
-        "summary": "Reports information. Supported subcommands are: MEMORY, DEPTH, FIELDS, HELP",
+        "summary": "Reports information. Supported subcommands are: MEMORY, DEPTH, FIELDS, HELP. KEYTABLE-CORRUPT, KEYTABLE-CLEAR, and KEYTABLE-DISTRIBUTION subcommands require 'json.debug-mode' to be enabled at module load time.",
         "complexity": "O(1)",
         "group": "json",
         "module_since": "1.0.0",

--- a/src/commands/json.mget.json
+++ b/src/commands/json.mget.json
@@ -1,6 +1,6 @@
 {
     "JSON.MGET": {
-        "summary": "Get serialized JSONs at the path from multiple document keys. Return null for non-existent key or JSON path.",
+        "summary": "Get serialized JSONs at the path from multiple document keys. Return null for nonexistent key or JSON path.",
         "complexity": "O(N) where N is the number of keys",
         "group": "json",
         "module_since": "1.0.0",

--- a/src/json/CPPLINT.cfg
+++ b/src/json/CPPLINT.cfg
@@ -1,2 +1,2 @@
-filter=-build/include_order,-legal/copyright,-whitespace/braces,-build/c++11,-runtime/references,-build/include_what_you_use,-readability/casting,-build/header_guard,-runtime/int,-build/namespaces,-runtime/explicit
+filter=-build/include_order,-legal/copyright,-whitespace/braces,-build/c++11,-runtime/references,-build/include_what_you_use,-readability/casting,-build/header_guard,-runtime/int,-build/namespaces,-runtime/explicit,-whitespace/end_of_line,-whitespace/ending_newline,-whitespace/comments,-whitespace/comma,-whitespace/indent,-whitespace/indent_namespace,-whitespace/blank_line,-whitespace/parens,-whitespace/line_length,-build/include_subdir,-build/include
 linelength=120

--- a/src/json/dom.cc
+++ b/src/json/dom.cc
@@ -1347,6 +1347,10 @@ enum meta_codes {
     JSON_METACODE_PAIR    = 0x80    // Codes an object Memory, a string(member name) and a JValue
 };
 
+// Cap pre-reservation for legacy RDB array loads: the declared count is untrusted
+// (RESTORE/replication), so limit upfront allocation; PushBack grows as elements arrive.
+static constexpr uint64_t JSON_RDB_ARRAY_RESERVE_CAP = 1ULL << 16;  // 65536 elements
+
 //
 // save a JValue, recurse as required for object and array
 //
@@ -1499,15 +1503,21 @@ JValue rdbLoadJValue(load_params *params) {
             uint64_t length = ValkeyModule_LoadUnsigned(params->rdb);
             JValue array;
             array.SetArray();
-            array.Reserve(length, allocator);
             if (params->nestLevel >= json_get_max_path_limit()) {
                 params->status = JSONUTIL_DOCUMENT_PATH_LIMIT_EXCEEDED;
                 ValkeyModule_LogIOError(params->rdb, "error", "document path limit exceeded");
                 return JValue();
             }
+            array.Reserve(std::min<uint64_t>(length, JSON_RDB_ARRAY_RESERVE_CAP), allocator);
             params->nestLevel++;
             while (length--) {
                 array.PushBack(rdbLoadJValue(params), allocator);
+                // Break on load failure or IO error to avoid unbounded loop.
+                if (params->status != JSONUTIL_SUCCESS || ValkeyModule_IsIOError(params->rdb)) {
+                    if (params->status == JSONUTIL_SUCCESS) params->status = JSONUTIL_INVALID_RDB_FORMAT;
+                    params->nestLevel--;
+                    return JValue();
+                }
             }
             params->nestLevel--;
             return array;
@@ -1543,6 +1553,12 @@ JsonUtilCode dom_load(JDocument **doc, ValkeyModuleIO *ctx, int encver) {
             params.nestLevel = 0;
             params.status = JSONUTIL_SUCCESS;
             JValue loadedValue = rdbLoadJValue(&params);
+            // Catch truncated-stream cases that didn't set status during recursion.
+            if (params.status == JSONUTIL_SUCCESS && ValkeyModule_IsIOError(ctx)) {
+                ValkeyModule_LogIOError(ctx, "warning",
+                    "IO error after rdbLoadJValue with success status; rejecting");
+                params.status = JSONUTIL_INVALID_RDB_FORMAT;
+            }
             if (params.status == JSONUTIL_SUCCESS) {
                 *doc = create_doc();
                 (*doc)->SetJValue(loadedValue);

--- a/src/json/dom.cc
+++ b/src/json/dom.cc
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <iomanip>
 #include <cmath>
+#include <algorithm>
 #include "json/rapidjson_includes.h"
 
 #define STATIC /* decorator for static functions, remove so that backtrace symbols include these */
@@ -37,6 +38,28 @@
 
 // the one true allocator
 RapidJsonAllocator allocator;
+
+ /**
+ * Order a unique result set deepest first, using most '/' separators.
+ * Ties retain original relative order via stable sort.
+ *
+ * A size changing mutation on an array invalidates cached JValue*
+ * pointers to its elements. Acting on descendants before ancestors ensures
+ * every pointer is still valid when dereferenced as a parent's buffer is never
+ * reallocated before its children are consumed.
+ *
+ * For result sets with no parent descendant overlap, this is a stable no-op.
+ */
+STATIC jsn::vector<size_t> order_result_set_deepest_first(const jsn::vector<Selector::ValueInfo> &rs) {
+    jsn::vector<size_t> order(rs.size());
+    for (size_t i = 0; i < rs.size(); i++) order[i] = i;
+    std::stable_sort(order.begin(), order.end(), [&rs](size_t a, size_t b) {
+        size_t depth_a = std::count(rs[a].second.begin(), rs[a].second.end(), '/');
+        size_t depth_b = std::count(rs[b].second.begin(), rs[b].second.end(), '/');
+        return depth_a > depth_b;  // deeper paths first
+    });
+    return order;
+}
 
 /**
  * We want to avoid all redundant creations of an allocator -- for performance reasons.
@@ -750,7 +773,11 @@ JsonUtilCode dom_array_append(ValkeyModuleCtx *ctx, JDocument *doc, const char *
     }
     CHECK_DOCUMENT_SIZE_LIMIT(ctx, doc->size, totalJValueSize)
 
-    for (auto &v : selector.getUniqueResultSet()) {
+    auto &rs = selector.getUniqueResultSet();
+    vec.resize(rs.size());
+    // Process matches deepest first. Results are written back to their original index.
+    for (size_t idx : order_result_set_deepest_first(rs)) {
+        auto &v = rs[idx];
         if (v.first->IsArray()) {
             for (size_t i=0; i < num_values; i++) {
                 // Need to make a copy of the value because after the first call of JValue::PushBack,
@@ -758,15 +785,15 @@ JsonUtilCode dom_array_append(ValkeyModuleCtx *ctx, JDocument *doc, const char *
                 JValue copy(appendVals[i], allocator);
                 v.first->PushBack(copy, allocator);
             }
-            vec.push_back(v.first->Size());
+            vec[idx] = v.first->Size();
         } else {
-            vec.push_back(SIZE_MAX);  // indicates non-array value
+            vec[idx] = SIZE_MAX;  // indicates non-array value
         }
     }
     return JSONUTIL_SUCCESS;
 }
 
-STATIC void internal_array_pop(JValue &arrVal, int64_t index, jsn::vector<rapidjson::StringBuffer> &vec,
+STATIC void internal_array_pop(JValue &arrVal, int64_t index, rapidjson::StringBuffer &out,
                                rapidjson::StringBuffer &oss) {
     // Convert negative index to positive
     int64_t size = arrVal.Size();
@@ -778,7 +805,7 @@ STATIC void internal_array_pop(JValue &arrVal, int64_t index, jsn::vector<rapidj
 
     serialize_value(arrVal[index], 0, nullptr, oss);
     arrVal.Erase(arrVal.Begin() + index);
-    vec.push_back(std::move(oss));
+    out = std::move(oss);
 }
 
 JsonUtilCode dom_array_pop(JDocument *doc, const char *path, int64_t index,
@@ -800,16 +827,20 @@ JsonUtilCode dom_array_pop(JDocument *doc, const char *path, int64_t index,
         if (!has_array_value(values)) return JSONUTIL_JSON_ELEMENT_NOT_ARRAY;
     }
 
-    for (auto &v : selector.getUniqueResultSet()) {
+    auto &rs = selector.getUniqueResultSet();
+    vec.resize(rs.size());
+    // Process matches deepest first. Results are written back to their original index.
+    for (size_t idx : order_result_set_deepest_first(rs)) {
+        auto &v = rs[idx];
         rapidjson::StringBuffer oss;
         if (v.first->IsArray()) {
             if (v.first->Empty()) {
-                vec.push_back(std::move(oss));  // empty array, oss is empty
+                vec[idx] = std::move(oss);  // empty array, oss is empty
             } else {
-                internal_array_pop(*v.first, index, vec, oss);
+                internal_array_pop(*v.first, index, vec[idx], oss);
             }
         } else {
-            vec.push_back(std::move(oss));  // non-array value, oss is empty
+            vec[idx] = std::move(oss);  // non-array value, oss is empty
         }
     }
 
@@ -817,7 +848,7 @@ JsonUtilCode dom_array_pop(JDocument *doc, const char *path, int64_t index,
 }
 
 STATIC JsonUtilCode internal_array_insert(JValue &arrVal, jsn::vector<JParser> &insertVals,
-                                          const size_t num_values, int64_t index, jsn::vector<size_t> &vec) {
+                                          const size_t num_values, int64_t index, size_t &out) {
     size_t size = arrVal.Size();
 
     // Negative index values are interpreted as starting from the end.
@@ -847,7 +878,7 @@ STATIC JsonUtilCode internal_array_insert(JValue &arrVal, jsn::vector<JParser> &
         arrVal[i] = copy;
     }
 
-    vec.push_back(arrVal.Size());
+    out = arrVal.Size();
     return JSONUTIL_SUCCESS;
 }
 
@@ -883,21 +914,25 @@ JsonUtilCode dom_array_insert(ValkeyModuleCtx *ctx, JDocument *doc, const char *
     }
     CHECK_DOCUMENT_SIZE_LIMIT(ctx, doc->size, totalJValueSize)
 
-    for (auto &v : selector.getUniqueResultSet()) {
+    auto &rs = selector.getUniqueResultSet();
+    vec.resize(rs.size());
+    // Process matches deepest first. Results are written back to their original index.
+    for (size_t idx : order_result_set_deepest_first(rs)) {
+        auto &v = rs[idx];
         if (v.first->IsArray()) {
-            rc = internal_array_insert(*v.first, insertVals, num_values, index, vec);
+            rc = internal_array_insert(*v.first, insertVals, num_values, index, vec[idx]);
             if (rc != JSONUTIL_SUCCESS) return rc;
         } else {
-            vec.push_back(SIZE_MAX);  // indicates non-array value
+            vec[idx] = SIZE_MAX;  // indicates non-array value
         }
     }
     return JSONUTIL_SUCCESS;
 }
 
-STATIC void internal_array_trim(JValue &arrVal, int64_t start, int64_t stop, jsn::vector<size_t> &vec) {
+STATIC void internal_array_trim(JValue &arrVal, int64_t start, int64_t stop, size_t &out) {
     int64_t size = static_cast<int64_t>(arrVal.Size());
     if (size == 0) {
-        vec.push_back(0);
+        out = 0;
         return;
     }
 
@@ -910,7 +945,7 @@ STATIC void internal_array_trim(JValue &arrVal, int64_t start, int64_t stop, jsn
     if (start >= size || start > stop) {
         // If start >= size or start > stop, empty the array and return *new_len as 0.
         arrVal.Erase(arrVal.Begin(), arrVal.End());
-        vec.push_back(0);
+        out = 0;
         return;
     }
 
@@ -919,7 +954,7 @@ STATIC void internal_array_trim(JValue &arrVal, int64_t start, int64_t stop, jsn
     if (start > 0)
         arrVal.Erase(arrVal.Begin(), arrVal.Begin() + start);
 
-    vec.push_back(arrVal.Size());
+    out = arrVal.Size();
 }
 
 JsonUtilCode dom_array_trim(JDocument *doc, const char *path, int64_t start, int64_t stop,
@@ -941,11 +976,15 @@ JsonUtilCode dom_array_trim(JDocument *doc, const char *path, int64_t start, int
         if (!has_array_value(values)) return JSONUTIL_JSON_ELEMENT_NOT_ARRAY;
     }
 
-    for (auto &v : selector.getUniqueResultSet()) {
+    auto &rs = selector.getUniqueResultSet();
+    vec.resize(rs.size());
+    // Process matches deepest first. Results are written back to their original index.
+    for (size_t idx : order_result_set_deepest_first(rs)) {
+        auto &v = rs[idx];
         if (v.first->IsArray()) {
-            internal_array_trim(*v.first, start, stop, vec);
+            internal_array_trim(*v.first, start, stop, vec[idx]);
         } else {
-            vec.push_back(SIZE_MAX);  // indicates non-array value
+            vec[idx] = SIZE_MAX;  // indicates non-array value
         }
     }
     return JSONUTIL_SUCCESS;
@@ -957,7 +996,10 @@ JsonUtilCode dom_clear(JDocument *doc, const char *path, size_t &elements_cleare
     JsonUtilCode rc = selector.getValues(doc->GetJValue(), path);
     if (rc != JSONUTIL_SUCCESS) return rc;
 
-    for (auto &v : selector.getUniqueResultSet()) {
+    auto &rs = selector.getUniqueResultSet();
+    // Process matches deepest-first. The reply is just a count, so order is irrelevant.
+    for (size_t idx : order_result_set_deepest_first(rs)) {
+        auto &v = rs[idx];
         if (v.first->IsArray()) {
             if (!v.first->Empty()) {
                 v.first->Erase(v.first->Begin(), v.first->End());

--- a/src/json/json.cc
+++ b/src/json/json.cc
@@ -50,7 +50,7 @@
 
 #define ERRMSG_JSON_DOCUMENT_NOT_FOUND "NONEXISTENT JSON document is not found"
 #define ERRMSG_NEW_VALKEY_KEY_PATH_NOT_ROOT "SYNTAXERR A new Valkey key's path must be root"
-#define ERRMSG_CANNOT_DISABLE_MODULE_DUE_TO_OUTSTADING_DATA \
+#define ERRMSG_CANNOT_DISABLE_MODULE_DUE_TO_OUTSTANDING_DATA \
     "Cannot disable the module because there are outstanding document keys"
 
 #define STATIC /* decorator for static functions, remove so that backtrace symbols include these */
@@ -965,7 +965,7 @@ int Command_JsonDel(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
 
     if (rc != JSONUTIL_SUCCESS) {
         if (rc == JSONUTIL_INVALID_JSON_PATH || rc == JSONUTIL_JSON_PATH_NOT_EXIST) {
-            // ignore invalid or non-existent path
+            // ignore invalid or nonexistent path
             return ValkeyModule_ReplyWithLongLong(ctx, 0);
         } else {
             return ValkeyModule_ReplyWithError(ctx, jsonutil_code_to_message(rc));
@@ -2290,7 +2290,7 @@ int Command_JsonDebug(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc)
 
         // ATTENTION:
         // THIS IS AN UNDOCUMENTED SUBCOMMAND, DON'T RUN IT ON A PRODUCTION SYSTEM
-        // UNLESS YOU KNOW WHAT YOU'RE DOING -- IT CAN LOCK THE MAINTHREAD FOR SEVERAL SECONDS
+        // UNLESS YOU KNOW WHAT YOU'RE DOING -- IT CAN LOCK THE MAIN THREAD FOR SEVERAL SECONDS
         //
 
 
@@ -2527,7 +2527,7 @@ int handleHashTableFactor(T rapidjson::HashTableFactors::*f, const void *v, T sc
 //
 // Resize the number of shards in the keyTable. this isn't multi-thread safe. But the current AppConfig architecture
 // doesn't provide a good way to solve this problem. Also, we only do it when the table is empty. As long as there
-// are no background operations in progress (slot migration, threadsave) we're good. Sadly there's no easy way for
+// are no background operations in progress (slot migration, threadsave), we're good. Sadly there's no easy way for
 // a module to detect that. Once we have RM_ApplyConfig, we'll restrict this to only happen at initialization time.
 // and close this small timing hole.
 //
@@ -3161,7 +3161,7 @@ extern "C" int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx) {
     }
 
     //
-    // Setup the global string table
+    // Set up the global string table
     //
     initKeyTable(KeyTable::MAX_SHARDS, KeyTable::Factors());
     if (configKeyTable() == VALKEYMODULE_ERR) return VALKEYMODULE_ERR;

--- a/src/json/json.cc
+++ b/src/json/json.cc
@@ -282,7 +282,6 @@ STATIC JsonUtilCode parseSetCmdArgs(ValkeyModuleString **argv, const int argc, S
 
 typedef struct {
     ValkeyModuleString *key_str;    // Required
-    ValkeyModuleKey *key;
     const char *path;               // Required
     const char *json;               // Required
     size_t json_len;
@@ -311,11 +310,11 @@ STATIC JsonUtilCode parseAndValidateMSetCmdArgs(ValkeyModuleCtx *ctx, ValkeyModu
         MSetCmdArgs &current_arg = (*args_list)[i];
 
         current_arg.key_str = argv[i * 3 + 1];
-        current_arg.key = static_cast<ValkeyModuleKey*>(
+        ValkeyModuleKey *key = static_cast<ValkeyModuleKey*>(
             ValkeyModule_OpenKey(ctx, current_arg.key_str, VALKEYMODULE_READ | VALKEYMODULE_WRITE));
 
         // Handle key allocation failure
-        if (!current_arg.key) {
+        if (!key) {
             rc = JSONUTIL_KEY_OPEN_ERROR;
             return rc;
         }
@@ -324,9 +323,9 @@ STATIC JsonUtilCode parseAndValidateMSetCmdArgs(ValkeyModuleCtx *ctx, ValkeyModu
         current_arg.json = ValkeyModule_StringPtrLen(argv[i * 3 + 3], &current_arg.json_len);
 
         // Validate key type
-        int type = ValkeyModule_KeyType(current_arg.key);
+        int type = ValkeyModule_KeyType(key);
         if (type != VALKEYMODULE_KEYTYPE_EMPTY &&
-            ValkeyModule_ModuleTypeGetType(current_arg.key) != DocumentType) {
+            ValkeyModule_ModuleTypeGetType(key) != DocumentType) {
             rc = JSONUTIL_NOT_A_DOCUMENT_KEY;
             return rc;
         }
@@ -358,7 +357,7 @@ STATIC JsonUtilCode parseAndValidateMSetCmdArgs(ValkeyModuleCtx *ctx, ValkeyModu
             }
             dom_free_doc(doc);
         } else {
-            JDocument *doc = static_cast<JDocument*>(ValkeyModule_ModuleTypeGetValue(current_arg.key));
+            JDocument *doc = static_cast<JDocument*>(ValkeyModule_ModuleTypeGetValue(key));
             if (!doc) {
                 rc = JSONUTIL_DOCUMENT_KEY_NOT_FOUND;
                 return rc;
@@ -739,6 +738,11 @@ int Command_JsonSet(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
     return ValkeyModule_ReplyWithSimpleString(ctx, "OK");
 }
 
+// JSON.MSET applies each key/path/value independently on a best-effort basis.
+// An op that no longer applies against the current document (for example because
+// an earlier op in the same command changed the document's shape) is skipped;
+// All applicable ops are applied and the command returns OK.
+// Replicate the command so replicas and the AOF apply the same best-effort result.
 int Command_JsonMSet(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
     ValkeyModule_AutoMemory(ctx);
 
@@ -753,44 +757,51 @@ int Command_JsonMSet(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) 
             return ValkeyModule_ReplyWithError(ctx, jsonutil_code_to_message(rc));
     }
 
-    // Apply changes
-    size_t i;
-    for (i = 0; i < num_keys; i++) {
-        // begin tracking memory
+    for (size_t i = 0; i < num_keys; i++) {
         int64_t begin_val = jsonstats_begin_track_mem();
 
-        if (args_list[i].is_root_path) { // Root document
-            // parse incoming JSON string
+        // Open the key fresh so each op sees the current value, even for duplicate keys
+        // where an earlier op may have replaced the document.
+        ValkeyModuleKey *key = static_cast<ValkeyModuleKey*>(
+            ValkeyModule_OpenKey(ctx, args_list[i].key_str, VALKEYMODULE_READ | VALKEYMODULE_WRITE));
+
+        if (args_list[i].is_root_path) {
             JDocument *doc;
             rc = dom_parse(ctx, args_list[i].json, args_list[i].json_len, &doc);
-            ValkeyModule_Assert(rc == JSONUTIL_SUCCESS);
+            if (rc != JSONUTIL_SUCCESS) {
+                jsonstats_end_track_mem(begin_val);
+                continue;  // skip this op
+            }
 
             int64_t delta = jsonstats_end_track_mem(begin_val);
             size_t doc_size = dom_get_doc_size(doc) + delta;
             dom_set_doc_size(doc, doc_size);
 
-            // Set Valkey key
-            ValkeyModule_ModuleTypeSetValue(args_list[i].key, DocumentType, doc);
-            // update stats
+            ValkeyModule_ModuleTypeSetValue(key, DocumentType, doc);
             jsonstats_update_stats_on_insert(doc, true, 0, doc_size, doc_size);
-        } else { // Update existing document
-            JDocument *doc = static_cast<JDocument*>(ValkeyModule_ModuleTypeGetValue(args_list[i].key));
+        } else {
+            JDocument *doc = static_cast<JDocument*>(ValkeyModule_ModuleTypeGetValue(key));
+            if (!doc) {
+                jsonstats_end_track_mem(begin_val);
+                continue;  // skip: key no longer holds a document
+            }
             size_t orig_doc_size = dom_get_doc_size(doc);
 
             rc = dom_set_value(ctx, doc, args_list[i].path, args_list[i].json, args_list[i].json_len, false, false);
-            ValkeyModule_Assert(rc == JSONUTIL_SUCCESS);
+            if (rc != JSONUTIL_SUCCESS) {
+                jsonstats_end_track_mem(begin_val);
+                continue;  // skip: path no longer valid against current document
+            }
             int64_t delta = jsonstats_end_track_mem(begin_val);
             size_t new_doc_size = dom_get_doc_size(doc) + delta;
             dom_set_doc_size(doc, new_doc_size);
 
-            // update stats
             jsonstats_update_stats_on_update(doc, orig_doc_size, new_doc_size, args_list[i].json_len);
         }
 
         ValkeyModule_NotifyKeyspaceEvent(ctx, VALKEYMODULE_NOTIFY_GENERIC, "json.mset", args_list[i].key_str);
     }
 
-    // replicate the entire command
     ValkeyModule_ReplicateVerbatim(ctx);
     ValkeyModule_Free(args_list);
     return ValkeyModule_ReplyWithSimpleString(ctx, "OK");

--- a/src/json/json.cc
+++ b/src/json/json.cc
@@ -2668,8 +2668,9 @@ extern "C" int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx) {
         return VALKEYMODULE_ERR;
     }
 
-    // Indicate that we can handle I/O errors ourself.
-    ValkeyModule_SetModuleOptions(ctx, VALKEYMODULE_OPTIONS_HANDLE_IO_ERRORS);
+    // Indicate that we can handle I/O errors ourself and repl async load.
+    // https://valkey.io/topics/modules-api-ref/#ValkeyModule_SetModuleOptions
+    ValkeyModule_SetModuleOptions(ctx, VALKEYMODULE_OPTIONS_HANDLE_IO_ERRORS | VALKEYMODULE_OPTIONS_HANDLE_REPL_ASYNC_LOAD);
 
     // Initialize metrics
     JsonUtilCode rc = jsonstats_init();

--- a/src/json/json.cc
+++ b/src/json/json.cc
@@ -367,6 +367,8 @@ STATIC JsonUtilCode parseAndValidateMSetCmdArgs(ValkeyModuleCtx *ctx, ValkeyModu
                 return rc;
             }
         }
+        // Close the validation handle so no stale handle to a duplicate key survives.
+        ValkeyModule_CloseKey(key);
     }
     return JSONUTIL_SUCCESS;
 }
@@ -770,6 +772,7 @@ int Command_JsonMSet(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) 
             rc = dom_parse(ctx, args_list[i].json, args_list[i].json_len, &doc);
             if (rc != JSONUTIL_SUCCESS) {
                 jsonstats_end_track_mem(begin_val);
+                ValkeyModule_CloseKey(key);
                 continue;  // skip this op
             }
 
@@ -783,6 +786,7 @@ int Command_JsonMSet(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) 
             JDocument *doc = static_cast<JDocument*>(ValkeyModule_ModuleTypeGetValue(key));
             if (!doc) {
                 jsonstats_end_track_mem(begin_val);
+                ValkeyModule_CloseKey(key);
                 continue;  // skip: key no longer holds a document
             }
             size_t orig_doc_size = dom_get_doc_size(doc);
@@ -790,6 +794,7 @@ int Command_JsonMSet(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) 
             rc = dom_set_value(ctx, doc, args_list[i].path, args_list[i].json, args_list[i].json_len, false, false);
             if (rc != JSONUTIL_SUCCESS) {
                 jsonstats_end_track_mem(begin_val);
+                ValkeyModule_CloseKey(key);
                 continue;  // skip: path no longer valid against current document
             }
             int64_t delta = jsonstats_end_track_mem(begin_val);
@@ -800,6 +805,9 @@ int Command_JsonMSet(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) 
         }
 
         ValkeyModule_NotifyKeyspaceEvent(ctx, VALKEYMODULE_NOTIFY_GENERIC, "json.mset", args_list[i].key_str);
+        // Close before the next op reopens this key; duplicate keys free the doc/key
+        // object, and a lingering handle would dangle at teardown (heap-use-after-free).
+        ValkeyModule_CloseKey(key);
     }
 
     ValkeyModule_ReplicateVerbatim(ctx);

--- a/src/json/json.cc
+++ b/src/json/json.cc
@@ -35,6 +35,7 @@
 
 #include <string>
 #include <cmath>
+#include <vector>
 
 #define MODULE_VERSION 10002 /* version 1.0.2 */
 #define MODULE_NAME "json"
@@ -73,11 +74,15 @@ static size_t config_max_recursive_descent_tokens = DEFAULT_MAX_RECURSIVE_DESCEN
 #define DEFAULT_MAX_QUERY_STRING_SIZE (128 * 1024)  // 128KB
 static size_t config_max_query_string_size = DEFAULT_MAX_QUERY_STRING_SIZE;
 
+static int config_debug_mode = 0;
+
 #define DEFAULT_KEY_TABLE_SHARDS 32768
 #define DEFAULT_HASH_TABLE_MIN_SIZE 64
 KeyTable *keyTable = nullptr;
 rapidjson::HashTableFactors rapidjson::hashTableFactors;
 rapidjson::HashTableStats   rapidjson::hashTableStats;
+
+static std::vector<KeyTable_Handle> debug_corrupt_handles;
 
 extern size_t hash_function(const char *text, size_t length);
 
@@ -2079,6 +2084,10 @@ STATIC int TestSharedApi(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int ar
     return VALKEYMODULE_OK;
 }
 
+static bool isDebugModeEnabled() {
+    return config_debug_mode != 0;
+}
+
 int Command_JsonDebug(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
     ValkeyModule_AutoMemory(ctx);
 
@@ -2209,6 +2218,10 @@ int Command_JsonDebug(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc)
             return VALKEYMODULE_ERR;
         }
 
+        if (!isDebugModeEnabled()) {
+            return ValkeyModule_ReplyWithError(ctx, "ERR unknown subcommand 'KEYTABLE-CORRUPT'. Try JSON.DEBUG HELP.");
+        }
+
         // ATTENTION:
         // THIS IS AN UNDOCUMENTED SUBCOMMAND, TO BE USED FOR DEV TEST ONLY. DON'T RUN IT ON A PRODUCTION SYSTEM.
         //
@@ -2222,13 +2235,38 @@ int Command_JsonDebug(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc)
         const char *str = ValkeyModule_StringPtrLen(argv[2], &len);
 
         KeyTable_Handle h = keyTable->makeHandle(str, len);
-        ValkeyModule_Log(ctx, "warning", "*** Handle %s count is now %zd", str, h->getRefCount());
+        ValkeyModule_Log(ctx, "warning",
+                         "KEYTABLE-CORRUPT: injected handle for input of %zu bytes, refcount=%zd",
+                         len, h->getRefCount());
+        debug_corrupt_handles.push_back(std::move(h));
         return ValkeyModule_ReplyWithSimpleString(ctx, "OK");
+    } else if (!strcasecmp(subcmd, "KEYTABLE-CLEAR")) {
+        if (ValkeyModule_IsKeysPositionRequest(ctx)) {
+            return VALKEYMODULE_ERR;
+        }
+
+        if (!isDebugModeEnabled()) {
+            return ValkeyModule_ReplyWithError(ctx, "ERR unknown subcommand 'KEYTABLE-CLEAR'. Try JSON.DEBUG HELP.");
+        }
+
+        if (argc != 2) return ValkeyModule_WrongArity(ctx);
+
+        size_t count = debug_corrupt_handles.size();
+        for (auto &h : debug_corrupt_handles) {
+            keyTable->destroyHandle(h);
+        }
+        debug_corrupt_handles.clear();
+        ValkeyModule_Log(ctx, "warning", "KEYTABLE-CLEAR: released %zu injected handles", count);
+        return ValkeyModule_ReplyWithLongLong(ctx, count);
     } else if (!strcasecmp(subcmd, "KEYTABLE-DISTRIBUTION")) {
         // compute longest runs of non-empty hashtable entries, a direct measure of key distribution and
         // worst-case run-time for lookup/insert/delete
         if (ValkeyModule_IsKeysPositionRequest(ctx)) {
             return VALKEYMODULE_ERR;
+        }
+
+        if (!isDebugModeEnabled()) {
+            return ValkeyModule_ReplyWithError(ctx, "ERR unknown subcommand 'KEYTABLE-DISTRIBUTION'. Try JSON.DEBUG HELP.");
         }
 
         // ATTENTION:
@@ -2281,6 +2319,7 @@ int Command_JsonDebug(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc)
         cmds.push_back("JSON.DEBUG MAX-SIZE-KEY  - Find JSON key with largest memory size");
         cmds.push_back("JSON.DEBUG KEYTABLE-CHECK - Extended KeyTable integrity check");
         cmds.push_back("JSON.DEBUG KEYTABLE-CORRUPT <name> - Intentionally corrupt KeyTable handle counts");
+        cmds.push_back("JSON.DEBUG KEYTABLE-CLEAR - Release all handles injected by KEYTABLE-CORRUPT");
         cmds.push_back("JSON.DEBUG KEYTABLE-DISTRIBUTION <topN> - Find and count topN longest runs in KeyTable");
         cmds.push_back("JSON.DEBUG TEST-SHARED-API <key> <path> - Provide testing for Shared api interface for search");
 
@@ -2551,12 +2590,31 @@ int Config_SetSizeConfig(const char *name, long long val, void *privdata, Valkey
     return VALKEYMODULE_OK;
 }
 
+int Config_GetBoolConfig(const char *name, void *privdata) {
+    VALKEYMODULE_NOT_USED(name);
+    return *static_cast<int*>(privdata);
+}
+
+int Config_SetBoolConfig(const char *name, int val, void *privdata, ValkeyModuleString **err) {
+    VALKEYMODULE_NOT_USED(name);
+    VALKEYMODULE_NOT_USED(err);
+    *static_cast<int*>(privdata) = val;
+    return VALKEYMODULE_OK;
+}
+
 int registerModuleConfigs(ValkeyModuleCtx *ctx) {
     REGISTER_NUMERIC_CONFIG(ctx, "max-document-size", DEFAULT_MAX_DOCUMENT_SIZE, VALKEYMODULE_CONFIG_MEMORY,
                             0, LLONG_MAX, &config_max_document_size, Config_GetSizeConfig, Config_SetSizeConfig)
 
     REGISTER_NUMERIC_CONFIG(ctx, "max-path-limit", DEFAULT_MAX_PATH_LIMIT, VALKEYMODULE_CONFIG_DEFAULT,
                             0, INT_MAX, &config_max_path_limit, Config_GetSizeConfig, Config_SetSizeConfig)
+
+    if (ValkeyModule_RegisterBoolConfig(ctx, "debug-mode", 0,
+            VALKEYMODULE_CONFIG_HIDDEN | VALKEYMODULE_CONFIG_IMMUTABLE,
+            Config_GetBoolConfig, Config_SetBoolConfig, nullptr, &config_debug_mode) == VALKEYMODULE_ERR) {
+        ValkeyModule_Log(ctx, "warning", "Failed to register module config \"debug-mode\".");
+        return VALKEYMODULE_ERR;
+    }
 
     ValkeyModule_LoadConfigs(ctx);
     return VALKEYMODULE_OK;
@@ -2953,11 +3011,15 @@ extern "C" int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx) {
         ValkeyModule_Log(ctx, "warning", "Failed to create subcommand KEYTABLE-CHECK for command JSON.DEBUG.");
         return VALKEYMODULE_ERR;
     }
-    if (ValkeyModule_CreateSubcommand(parent, "KEYTABLE-CORRUPT", Command_JsonDebug, "", 2, 2, 1) == VALKEYMODULE_ERR) {
+    if (ValkeyModule_CreateSubcommand(parent, "KEYTABLE-CORRUPT", Command_JsonDebug, "admin", 2, 2, 1) == VALKEYMODULE_ERR) {
         ValkeyModule_Log(ctx, "warning", "Failed to create subcommand KEYTABLE-CORRUPT for command JSON.DEBUG.");
         return VALKEYMODULE_ERR;
     }
-    if (ValkeyModule_CreateSubcommand(parent, "KEYTABLE-DISTRIBUTION", Command_JsonDebug, "", 0, 0, 0)
+    if (ValkeyModule_CreateSubcommand(parent, "KEYTABLE-CLEAR", Command_JsonDebug, "admin", 0, 0, 0) == VALKEYMODULE_ERR) {
+        ValkeyModule_Log(ctx, "warning", "Failed to create subcommand KEYTABLE-CLEAR for command JSON.DEBUG.");
+        return VALKEYMODULE_ERR;
+    }
+    if (ValkeyModule_CreateSubcommand(parent, "KEYTABLE-DISTRIBUTION", Command_JsonDebug, "admin", 0, 0, 0)
         == VALKEYMODULE_ERR) {
         ValkeyModule_Log(ctx, "warning", "Failed to create subcommand KEYTABLE-DISTRIBUTION for command JSON.DEBUG.");
         return VALKEYMODULE_ERR;
@@ -3071,6 +3133,7 @@ extern "C" int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx) {
     if (!set_command_info(ctx, "JSON.DEBUG|MAX-SIZE-KEY", 2)) return VALKEYMODULE_ERR;
     if (!set_command_info(ctx, "JSON.DEBUG|KEYTABLE-CHECK", 2)) return VALKEYMODULE_ERR;
     if (!set_command_info(ctx, "JSON.DEBUG|KEYTABLE-CORRUPT", 3)) return VALKEYMODULE_ERR;
+    if (!set_command_info(ctx, "JSON.DEBUG|KEYTABLE-CLEAR", 2)) return VALKEYMODULE_ERR;
     if (!set_command_info(ctx, "JSON.DEBUG|KEYTABLE-DISTRIBUTION", 3)) return VALKEYMODULE_ERR;
 
     if (!memory_traps_control(false)) {

--- a/src/json/keytable.cc
+++ b/src/json/keytable.cc
@@ -418,7 +418,7 @@ struct KeyTable_Shard {
 };
 
 /*
- * Setup the KeyTable itself.
+ * Set up the KeyTable itself.
  */
 KeyTable::KeyTable(const Config& cfg) :
     malloc(cfg.malloc),

--- a/src/json/keytable.h
+++ b/src/json/keytable.h
@@ -307,7 +307,7 @@ struct KeyTable {
     const Factors& getFactors() const { return factors; }
     //
     // Query if this set of factors is valid.
-    // returns: NULL, If the factors are valid. Otherwise an error string
+    // returns: NULL, If the factors are valid. Otherwise, an error string
     // This is used to validate a set of factors before setting them.
     //
     static const char *isValidFactors(const Factors& f);

--- a/src/json/selector.cc
+++ b/src/json/selector.cc
@@ -616,6 +616,15 @@ struct pathCompare {
         JPointer ptr2 = JPointer(path2);
         size_t depth1 = ptr1.GetTokenCount();
         size_t depth2 = ptr2.GetTokenCount();
+
+        // Guard against invalid pointers. A malformed JSON pointer parses to zero tokens, and
+        // because depth is size_t, tokenArray[depth - 1] below would underflow to (size_t)-1 and
+        // read out of bounds. Fall back to a stable lexicographic ordering of the raw paths.
+        if (ptr1.HasError() || ptr2.HasError() || depth1 == 0 || depth2 == 0) {
+            if (depth1 != depth2) return depth1 > depth2;
+            return path1 > path2;
+        }
+
         if (depth1 != depth2) return depth1 > depth2;
 
         const JPointer::Token* tokenArray1 = ptr1.GetTokens();
@@ -2425,7 +2434,9 @@ void Selector::dedupe() {
 
 void Selector::escape_member_name_for_json_pointer(const std::string_view &member_name, std::ostringstream &oss) {
     for (char c : member_name) {
-        if (c == '/') {
+        if (c == '~') {
+            oss << "~0";
+        } else if (c == '/') {
             oss << "~1";
         } else {
             oss << c;

--- a/src/rapidjson/document.h
+++ b/src/rapidjson/document.h
@@ -2615,7 +2615,7 @@ private:
         // Move the members from the copy into the new hashtable
         //
         [[maybe_unused]] size_t object_member_count = 0;
-        size_t object_num_member_chars = 0;
+        [[maybe_unused]] size_t object_num_member_chars = 0;
         for (MemberIterator i = me.MemberBegin(); i != me.MemberEnd(); ++i) {
             object_member_count += 1;
             object_num_member_chars += i->name.GetStringLength();

--- a/src/rapidjson/document.h
+++ b/src/rapidjson/document.h
@@ -32,6 +32,7 @@
 #include <new>     // placement new
 #include <limits>
 #include <atomic>
+#include <cstdlib>  // std::strtod
 #ifdef __cpp_lib_three_way_comparison
 #include <compare>
 #endif
@@ -1918,7 +1919,7 @@ public:
     */
     double GetDouble() const {
         RAPIDJSON_ASSERT(IsNumber());
-        if ((data_.f.flags & kDoubleFlag) != 0)                { return std::stod(DataString(data_)); }   // convert from string to double.
+        if ((data_.f.flags & kDoubleFlag) != 0)                { return std::strtod(DataString(data_), nullptr);}  // convert from string to double.
         if ((data_.f.flags & kIntFlag) != 0)                   return data_.n.i.i; // int -> double
         if ((data_.f.flags & kUintFlag) != 0)                  return data_.n.u.u; // unsigned -> double
         if ((data_.f.flags & kInt64Flag) != 0)                 return static_cast<double>(data_.n.i64); // int64_t -> double (may lose precision)

--- a/src/rapidjson/document.h
+++ b/src/rapidjson/document.h
@@ -405,7 +405,7 @@ struct GenericStringRef {
     //! Explicitly create string reference from \c const character pointer
 #ifndef __clang__ // -Wdocumentation
     /*!
-        This constructor can be used to \b explicitly  create a reference to
+        This constructor can be used to \b explicitly create a reference to
         a constant string pointer.
 
         \see StringRef(const CharType*)
@@ -1040,9 +1040,9 @@ public:
     */
     GenericValue& operator=(GenericValue& rhs) RAPIDJSON_NOEXCEPT {
         if (RAPIDJSON_LIKELY(this != &rhs)) {
-            // Can't destroy "this" before assigning "rhs", otherwise "rhs"
-            // could be used after free if it's an sub-Value of "this",
-            // hence the temporary danse.
+            // Can't destroy "this" before assigning "rhs"; otherwise, "rhs"
+            // could be used after free if it's a sub-Value of "this",
+            // hence the temporary dance.
             GenericValue temp;
             temp.RawAssign(rhs, false); // valid
             this->~GenericValue();
@@ -1915,7 +1915,7 @@ public:
     uint64_t GetUint64() const  { RAPIDJSON_ASSERT(data_.f.flags & kUint64Flag); return data_.n.u64; }
 
     //! Get the value as double type.
-    /*! \note If the value is 64-bit integer type, it may lose precision. Use \c IsLosslessDouble() to check whether the converison is lossless.
+    /*! \note If the value is 64-bit integer type, it may lose precision. Use \c IsLosslessDouble() to check whether the conversion is lossless.
     */
     double GetDouble() const {
         RAPIDJSON_ASSERT(IsNumber());
@@ -2791,7 +2791,7 @@ private:
         for (size_t count = 0; count <= data_.o.capacity; ++count) {
             MemberHT& thisEntry = m[ix];
             if (!thisEntry.name) {
-                trace("Removemember, scan complete");
+                trace("RemoveMember, scan complete");
                 if (loadFactor() < hashTableFactors.minLoad) {
                     //
                     // See DoConstructHT

--- a/src/rapidjson/reader.h
+++ b/src/rapidjson/reader.h
@@ -71,7 +71,7 @@ RAPIDJSON_DIAG_OFF(effc++)
     \ingroup RAPIDJSON_ERRORS
     \brief Macro to indicate a parse error.
     \param parseErrorCode \ref rapidjson::ParseErrorCode of the error
-    \param offset  position of the error in JSON input (\c size_t)
+    \param offset position of the error in JSON input (\c size_t)
 
     This macros can be used as a customization point for the internal
     error handling mechanism of RapidJSON.
@@ -109,7 +109,7 @@ RAPIDJSON_DIAG_OFF(effc++)
     \ingroup RAPIDJSON_ERRORS
     \brief (Internal) macro to indicate and handle a parse error.
     \param parseErrorCode \ref rapidjson::ParseErrorCode of the error
-    \param offset  position of the error in JSON input (\c size_t)
+    \param offset position of the error in JSON input (\c size_t)
 
     Invokes RAPIDJSON_PARSE_ERROR_NORETURN and stops the parsing.
 
@@ -1210,7 +1210,7 @@ private:
         is.dst_ = q;
     }
 
-    // When read/write pointers are the same for insitu stream, just skip unescaped characters
+    // When read/write pointers are the same for in situ stream, just skip unescaped characters
     static RAPIDJSON_FORCEINLINE void SkipUnescapedString(InsituStringStream& is) {
         RAPIDJSON_ASSERT(is.src_ == is.dst_);
         char* p = is.src_;
@@ -1382,7 +1382,7 @@ private:
         is.dst_ = q;
     }
 
-    // When read/write pointers are the same for insitu stream, just skip unescaped characters
+    // When read/write pointers are the same for in situ stream, just skip unescaped characters
     static RAPIDJSON_FORCEINLINE void SkipUnescapedString(InsituStringStream& is) {
         RAPIDJSON_ASSERT(is.src_ == is.dst_);
         char* p = is.src_;
@@ -1428,7 +1428,7 @@ private:
         is.src_ = is.dst_ = p;
     }
 #else
-    // When read/write pointers are the same for insitu stream, just skip unescaped characters
+    // When read/write pointers are the same for in situ stream, just skip unescaped characters
     static RAPIDJSON_FORCEINLINE void SkipUnescapedString(InsituStringStream& is) {
         RAPIDJSON_ASSERT(is.src_ == is.dst_);
         char* p = is.src_;

--- a/src/rapidjson/writer.h
+++ b/src/rapidjson/writer.h
@@ -293,7 +293,7 @@ protected:
     struct Level {
         Level(bool inArray_) : valueCount(0), inArray(inArray_) {}
         size_t valueCount;  //!< number of values in this level
-        bool inArray;       //!< true if in array, otherwise in object
+        bool inArray;       //!< true if in array; otherwise, in object
     };
 
     bool WriteNull()  {

--- a/tst/integration/README.md
+++ b/tst/integration/README.md
@@ -6,5 +6,5 @@ This directory contains integration tests that verify the interaction between vl
 
 ```text
 python 3.9
-pytest 4
+pytest 7.4.3
 ```

--- a/tst/integration/README.md
+++ b/tst/integration/README.md
@@ -1,6 +1,6 @@
 # Integration Tests
 
-This directory contains integration tests that verify the interaction between vlkaye-server and valkey-json module features working together. Unlike unit tests that test individual components in isolation, these tests validate the system's behavior as a whole.
+This directory contains integration tests that verify the interaction between valkey-server and valkey-json module features working together. Unlike unit tests that test individual components in isolation, these tests validate the system's behavior as a whole.
 
 ## Requirements
 

--- a/tst/integration/json_test_case.py
+++ b/tst/integration/json_test_case.py
@@ -76,7 +76,7 @@ class JsonTestCase(SimpleTestCase):
         else:
             # Original local server
             server_path = f"{os.path.dirname(os.path.realpath(__file__))}/.build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
-            args = {'loadmodule': os.getenv('MODULE_PATH'), "enable-debug-command": "local", 'enable-protected-configs': 'yes'}
+            args = {'loadmodule': os.getenv('MODULE_PATH'), 'json.debug-mode': 'yes', "enable-debug-command": "local", 'enable-protected-configs': 'yes'}
             self.server, self.client = self.create_server(testdir=self.testdir, server_path=server_path, args=args)
 
         self.error_class = ErrorStringTester

--- a/tst/integration/run.sh
+++ b/tst/integration/run.sh
@@ -27,28 +27,64 @@ fi
 
 if [[ $1 == "test" ]] ; then
     if [ ! -z "${ASAN_BUILD}" ]; then
-        echo "Running tests and checking for memory leaks"
+        echo "Running tests with AddressSanitizer enabled"
+
+        # Make ASAN/LSAN report reliably. Reports go to stderr detect_leaks=1 enables 
+        # leak checks at process exit. We do not abort the process so pytest can finish;
+        # any error is caught via the log scan and the pytest exit code below.
+        export ASAN_OPTIONS="detect_leaks=1:halt_on_error=0:abort_on_error=0:log_path=stderr${ASAN_OPTIONS:+:${ASAN_OPTIONS}}"
+
+        # Propagate the real pytest exit status through the pipe to tee.
+        set -o pipefail
         python -m pytest --capture=sys --html=report.html --cache-clear -v ${TEST_FLAG} ./ ${TEST_PATTERN} 2>&1 | tee test_output.tmp
-        # Check for memory leaks in the output
+        PYTEST_STATUS=${PIPESTATUS[0]}
+        set +o pipefail
+
+        RED='\033[0;31m'
+        NC='\033[0m'
+        FAILED=0
+
+        # 1) Any AddressSanitizer error: heap-buffer-overflow, heap-use-after-free,
+        #    stack/global-buffer-overflow, etc.
+        if grep -Eq "(ERROR|WARNING): AddressSanitizer:|SUMMARY: AddressSanitizer:" test_output.tmp; then
+            echo -e "${RED}AddressSanitizer reported errors:${NC}"
+            grep -nE "(ERROR|WARNING): AddressSanitizer:|SUMMARY: AddressSanitizer:" test_output.tmp | \
+            while read -r line; do
+                echo "::error::ASAN: ${line}"
+            done
+            FAILED=1
+        fi
+
+        # 2) Memory leaks reported by LeakSanitizer.
         if grep -q "LeakSanitizer: detected memory leaks" test_output.tmp; then
-            RED='\033[0;31m'
-            echo -e "${RED}Memory leaks detected in the following tests:"
+            echo -e "${RED}Memory leaks detected in the following tests:${NC}"
             LEAKING_TESTS=$(grep -B 2 "LeakSanitizer: detected memory leaks" test_output.tmp | \
                             grep -v "LeakSanitizer" | \
                             grep ".*\.py::")
-            
-            LEAK_COUNT=$(echo "$LEAKING_TESTS" | wc -l)
-            
+
+            LEAK_COUNT=$(echo "$LEAKING_TESTS" | grep -c .)
+
             # Output each leaking test
             echo "$LEAKING_TESTS" | while read -r line; do
-                echo "::error::Test with leak: $line"
+                [ -n "$line" ] && echo "::error::Test with leak: ${line}"
             done
-            
-            echo -e "\n$LEAK_COUNT python integration tests have leaks detected in them"
-            rm test_output.tmp
+
+            echo -e "\n${LEAK_COUNT} python integration tests have leaks detected in them"
+            FAILED=1
+        fi
+
+        # 3) pytest itself failed (assertion failure, or a server crash caused by a
+        #    fatal ASAN error that terminated the process mid-test).
+        if [ "${PYTEST_STATUS}" -ne 0 ]; then
+            echo -e "${RED}pytest exited with status ${PYTEST_STATUS}${NC}"
+            echo "::error::pytest exited with status ${PYTEST_STATUS}"
+            FAILED=1
+        fi
+
+        rm -f test_output.tmp
+        if [ "${FAILED}" -ne 0 ]; then
             exit 1
         fi
-        rm test_output.tmp
     else
         python -m pytest --html=report.html --cache-clear -v ${TEST_FLAG} ./ ${TEST_PATTERN}
     fi

--- a/tst/integration/run.sh
+++ b/tst/integration/run.sh
@@ -1,13 +1,5 @@
 #!/usr/bin/env bash
 
-# Sometimes processes are left running when test is cancelled.
-# Therefore, before build start, we kill all running test processes left from previous test run.
-echo "Kill old running test"
-pkill -9 -x Pytest || true
-pkill -9 -f "valkey-server.*:" || true
-pkill -9 -f Valgrind || true
-pkill -9 -f "valkey-benchmark" || true
-
 # If environment variable SERVER_VERSION is not set, default to "unstable"
 if [ -z "$SERVER_VERSION" ]; then
     echo "SERVER_VERSION environment variable is not set. Defaulting to \"unstable\"."

--- a/tst/integration/test_json_basic.py
+++ b/tst/integration/test_json_basic.py
@@ -2975,6 +2975,67 @@ class TestJsonBasic(JsonTestCase):
             assert value.encode() == client.execute_command(
                 'JSON.GET', key, path)
 
+    def test_json_mset_duplicate_key_root_then_path(self):
+        """Best-effort: root replace then conflicting path op on same key.
+        The root op applies, the path op is skipped (path no longer valid),
+        command returns OK, server stays alive."""
+        client = self.server.get_new_client()
+        dk = 'dk'
+        client.execute_command('JSON.SET', dk, '$', '{"a":1}')
+        # Op1 replaces root with array, op2 references .a which no longer exists
+        assert b'OK' == client.execute_command('JSON.MSET', dk, '$', '[1,2,3]', dk, '.a', '99')
+        # Server alive
+        assert client.execute_command('PING')
+        # Op1 applied, op2 skipped
+        assert b'[1,2,3]' == client.execute_command('JSON.GET', dk, '.')
+
+    def test_json_mset_duplicate_key_nested_path(self):
+        """Best-effort: nested object replacement then deeper path on same key.
+        First op applies, second is skipped (path no longer valid),
+        command returns OK."""
+        client = self.server.get_new_client()
+        dk = 'dk'
+        client.execute_command('JSON.SET', dk, '$', '{"a":{"x":1}}')
+        # Op1 replaces .a with array, op2 references .a.x which no longer exists
+        assert b'OK' == client.execute_command('JSON.MSET', dk, '.a', '[9]', dk, '.a.x', '5')
+        assert client.execute_command('PING')
+        # Op1 applied, op2 skipped
+        assert b'[9]' == client.execute_command('JSON.GET', dk, '.a')
+
+    def test_json_mset_duplicate_key_3ops_best_effort(self):
+        """Best-effort continues past conflicts: op1 ok, op2 conflicts, op3 ok.
+        A conflicting op is skipped and the remaining ops are still applied."""
+        client = self.server.get_new_client()
+        dk = 'dk'
+        k = 'mset3opk'
+        client.execute_command('JSON.SET', dk, '$', '{"a":1}')
+        client.execute_command('JSON.SET', k, '$', '{"v":0}')
+        # Op1: replace dk root (ok)
+        # Op2: set dk .a (conflicts - path gone after op1, skipped)
+        # Op3: update k .v (applied - best-effort continues past op2)
+        assert b'OK' == client.execute_command('JSON.MSET',
+                                              dk, '$', '[1,2,3]',
+                                              dk, '.a', '99',
+                                              k, '.v', '42')
+        assert client.execute_command('PING')
+        # Op1 applied
+        assert b'[1,2,3]' == client.execute_command('JSON.GET', dk, '.')
+        # Op3 applied (best-effort continues past conflict)
+        assert b'{"v":42}' == client.execute_command('JSON.GET', k, '.')
+
+    def test_json_mset_duplicate_key_later_op_valid(self):
+        """Duplicate key where the later op IS valid against the earlier op's result.
+        Op1 replaces root with {"b":1}, op2 sets .b to 2 on the new doc.
+        Both ops apply because each iteration opens the key fresh."""
+        client = self.server.get_new_client()
+        dk = 'dk'
+        client.execute_command('JSON.SET', dk, '$', '{"a":1}')
+        # Op1 replaces root, op2 sets .b on the NEW root — valid composition
+        assert b'OK' == client.execute_command('JSON.MSET', dk, '$', '{"b":1}', dk, '.b', '2')
+        assert client.execute_command('PING')
+        # Both ops applied: op1 set {"b":1}, op2 updated .b to 2
+        assert b'{"b":2}' == client.execute_command('JSON.GET', dk, '.')
+
     def test_multi_exec(self):
         client = self.server.get_new_client()
         client.execute_command('MULTI')

--- a/tst/integration/test_json_basic.py
+++ b/tst/integration/test_json_basic.py
@@ -182,7 +182,7 @@ class TestJsonBasic(JsonTestCase):
         else:
             # Original local server setup
             server_path = f"{os.path.dirname(os.path.realpath(__file__))}/.build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
-            args = {'loadmodule': os.getenv('MODULE_PATH'), "enable-debug-command": "local", 'enable-protected-configs': 'yes'}
+            args = {'loadmodule': os.getenv('MODULE_PATH'), 'json.debug-mode': 'yes', "enable-debug-command": "local", 'enable-protected-configs': 'yes'}
             self.server, self.client = self.create_server(testdir=self.testdir, server_path=server_path, args=args)
 
         self.error_class = ErrorStringTester
@@ -2747,6 +2747,33 @@ class TestJsonBasic(JsonTestCase):
         exp_val = client.execute_command('JSON.DEBUG','MEMORY',wikipedia,'.')
         assert exp_val == metadate_val
 
+    def test_keytable_corrupt_injects_handle(self):
+        """JSON.DEBUG KEYTABLE-CORRUPT should inject a handle that KEYTABLE-CHECK detects as a mismatch."""
+        client = self.server.get_new_client()
+        # Baseline: KEYTABLE-CHECK should succeed
+        client.execute_command('JSON.DEBUG', 'KEYTABLE-CHECK')
+        # Inject a handle
+        client.execute_command('JSON.DEBUG', 'KEYTABLE-CORRUPT', 'unique_test_corrupt_string_abc123')
+        # KEYTABLE-CHECK now detects the mismatch
+        with pytest.raises(ResponseError, match="Mismatch"):
+            client.execute_command('JSON.DEBUG', 'KEYTABLE-CHECK')
+        # Clean up so teardown doesn't trip the assertion
+        client.execute_command('JSON.DEBUG', 'KEYTABLE-CLEAR')
+
+    def test_keytable_clear_releases_handles(self):
+        """JSON.DEBUG KEYTABLE-CLEAR should release all injected handles and restore integrity."""
+        client = self.server.get_new_client()
+        # Inject 3 handles
+        client.execute_command('JSON.DEBUG', 'KEYTABLE-CORRUPT', 'clear_test_string_1')
+        client.execute_command('JSON.DEBUG', 'KEYTABLE-CORRUPT', 'clear_test_string_2')
+        client.execute_command('JSON.DEBUG', 'KEYTABLE-CORRUPT', 'clear_test_string_3')
+        # Clear them
+        cleared = client.execute_command('JSON.DEBUG', 'KEYTABLE-CLEAR')
+        assert cleared == 3, f"Expected 3 cleared handles, got {cleared}"
+        # KEYTABLE-CHECK succeeds again after cleanup
+        client.execute_command('JSON.DEBUG', 'KEYTABLE-CHECK')
+
+
     def test_json_duplicate_keys(self):
         client = self.server.get_new_client()
         '''Test handling of object with duplicate keys'''
@@ -4213,7 +4240,7 @@ class TestJsonBasic(JsonTestCase):
         cmd_arity = [('MEMORY', -3), ('FIELDS', -3), ('DEPTH', 3), ('HELP', 2),
                      ('MAX-DEPTH-KEY', 2), ('MAX-SIZE-KEY',
                                             2), ('KEYTABLE-CHECK', 2), ('KEYTABLE-CORRUPT', 3),
-                     ('KEYTABLE-DISTRIBUTION', 3), ('TEST-SHARED-API', -2)]
+                     ('KEYTABLE-CLEAR', 2), ('KEYTABLE-DISTRIBUTION', 3), ('TEST-SHARED-API', -2)]
         subcmd_dict = {f'JSON.DEBUG|{cmd}': arity for cmd, arity in cmd_arity}
 
         output = client.execute_command(
@@ -4355,3 +4382,43 @@ class TestJsonBasic(JsonTestCase):
             s = client.execute_command("json.debug", "test-shared-api", "k1", path)
             print("For Path:", path, " json.get:", g, " shared-api:", s)
             assert (g == s)
+
+
+class TestJsonDebugGating(JsonTestCase):
+    """Test that debug commands are gated behind json.debug-mode module config."""
+
+    @pytest.fixture(autouse=True)
+    def setup_test(self, setup):
+        use_external = os.environ.get("VALKEY_EXTERNAL_SERVER", "false").lower() == "true"
+
+        if use_external:
+            external_host = os.environ.get("VALKEY_HOST", "localhost")
+            external_port = int(os.environ.get("VALKEY_PORT", "6379"))
+            self.server, self.client = self.create_server(
+                testdir=self.testdir,
+                bind_ip=external_host,
+                port=external_port,
+                external_server=True
+            )
+        else:
+            server_path = f"{os.path.dirname(os.path.realpath(__file__))}/.build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
+            # Load module WITHOUT debug-mode — commands should be gated
+            args = {'loadmodule': os.getenv('MODULE_PATH'), "enable-debug-command": "local", 'enable-protected-configs': 'yes'}
+            self.server, self.client = self.create_server(testdir=self.testdir, server_path=server_path, args=args)
+
+        self.error_class = ErrorStringTester
+
+    def test_keytable_corrupt_requires_debug_mode(self):
+        """KEYTABLE-CORRUPT should be rejected without debug-mode."""
+        with pytest.raises(ResponseError, match="unknown subcommand"):
+            self.client.execute_command('JSON.DEBUG', 'KEYTABLE-CORRUPT', 'test_string')
+
+    def test_keytable_clear_requires_debug_mode(self):
+        """KEYTABLE-CLEAR should be rejected without debug-mode."""
+        with pytest.raises(ResponseError, match="unknown subcommand"):
+            self.client.execute_command('JSON.DEBUG', 'KEYTABLE-CLEAR')
+
+    def test_keytable_distribution_requires_debug_mode(self):
+        """KEYTABLE-DISTRIBUTION should be rejected without debug-mode."""
+        with pytest.raises(ResponseError, match="unknown subcommand"):
+            self.client.execute_command('JSON.DEBUG', 'KEYTABLE-DISTRIBUTION', '10')

--- a/tst/integration/test_json_basic.py
+++ b/tst/integration/test_json_basic.py
@@ -514,8 +514,8 @@ class TestJsonBasic(JsonTestCase):
         for (path, value) in [('.firstName', '"John"'),         # string
                               ('.address.city', '"New York"'),  # string
                               ('.spouse', 'null'),              # null
-                              ('.children', '[]'),              # empy array
-                              ('.groups', '{}'),                # empy object
+                              ('.children', '[]'),              # empty array
+                              ('.groups', '{}'),                # empty object
                               ('.isAlive', 'true'),             # boolean
                               ('.age', '27')]:           # float number
             assert value.encode() == client.execute_command(
@@ -525,7 +525,7 @@ class TestJsonBasic(JsonTestCase):
             assert value == client.execute_command(
                 'JSON.GET', wikipedia, path).decode()
 
-    def test_json_path_syntax_objectkeys(self):
+    def test_json_path_syntax_object_keys(self):
         client = self.server.get_new_client()
         for (path, value) in [('["firstName"]', '"John"'),
                               ('address[\'city\']', '"New York"'),
@@ -832,7 +832,7 @@ class TestJsonBasic(JsonTestCase):
             assert exp == client.execute_command(
                 'JSON.GET', key, path)
 
-        # Legacy path returns non-existent error if no value is selected.
+        # Legacy path returns nonexistent error if no value is selected.
         for (key, path, exp) in [
             (k1, '.a[*]', None),
             (k2, '.a.*', None)
@@ -1013,7 +1013,7 @@ class TestJsonBasic(JsonTestCase):
         ]:
             assert exp.encode() == client.execute_command('JSON.GET', k2, path)
 
-        # we do not support mixing of  unions and slices, nor do we support extraneous commas
+        # we do not support mixing of unions and slices, nor do we support extraneous commas
         for path in [
             '$[0,1,2:4]',
             '$[0:2,3,4]',
@@ -1541,7 +1541,7 @@ class TestJsonBasic(JsonTestCase):
         '''
         Test that double values remain consistent when going through JSON Engine.
             This tests a tolerance of 2^-50 for a decent number of iterations,
-            but is not enough to guarantee that level of presicion to our customers.
+            but is not enough to guarantee that level of precision to our customers.
         Also verify that regular and pretty print double values have the same output.
         '''
         client = self.server.get_new_client()
@@ -1902,7 +1902,7 @@ class TestJsonBasic(JsonTestCase):
             assert exp_new_str == client.execute_command(
                 'JSON.GET', key, path).decode()
 
-    def test_json_objectlen_command(self):
+    def test_json_object_len_command(self):
         client = self.server.get_new_client()
         assert 4 == client.execute_command(
             'JSON.OBJLEN', wikipedia, '.address')
@@ -1973,7 +1973,7 @@ class TestJsonBasic(JsonTestCase):
                     'JSON.OBJLEN', key, path)
             assert self.error_class.is_wrongtype_error(str(e.value))
 
-    def test_json_objectkeys_command(self):
+    def test_json_object_keys_command(self):
         client = self.server.get_new_client()
         obj_keys = [b'street', b'city', b'state', b'zipcode']
         assert obj_keys == client.execute_command(
@@ -2709,13 +2709,13 @@ class TestJsonBasic(JsonTestCase):
                           [b'number', b'646 555-4567']]
 
     def test_json_debug_memory(self):
-        # non-existent key
+        # nonexistent key
         client = self.server.get_new_client()
 
         assert None == client.execute_command(
             'JSON.DEBUG MEMORY', nonexistentkey)
 
-        # non-existent path
+        # nonexistent path
         with pytest.raises(ResponseError) as e:
             client.execute_command(
                 'JSON.DEBUG MEMORY', wikipedia, nonexistentpath)
@@ -2743,9 +2743,9 @@ class TestJsonBasic(JsonTestCase):
 
         # Verify the document size calculated by the "per document memory tracking" machinery matches the size
         # calculated by the method of walking the JSON tree.
-        metadate_val = client.execute_command('JSON.DEBUG','MEMORY',wikipedia)
+        metadata_val = client.execute_command('JSON.DEBUG','MEMORY',wikipedia)
         exp_val = client.execute_command('JSON.DEBUG','MEMORY',wikipedia,'.')
-        assert exp_val == metadate_val
+        assert exp_val == metadata_val
 
     def test_keytable_corrupt_injects_handle(self):
         """JSON.DEBUG KEYTABLE-CORRUPT should inject a handle that KEYTABLE-CHECK detects as a mismatch."""

--- a/tst/integration/test_json_basic.py
+++ b/tst/integration/test_json_basic.py
@@ -4444,6 +4444,56 @@ class TestJsonBasic(JsonTestCase):
             print("For Path:", path, " json.get:", g, " shared-api:", s)
             assert (g == s)
 
+    def test_recursive_path_mutation_use_after_free(self):
+        '''
+        Regression test for a use-after-free crash in size-changing array/clear mutators.
+
+        Root cause: a node's JValue* points into its parent array's element buffer. When a
+        recursive path (e.g. $.. or $[*]) selects both a parent array and a descendant that
+        lives inside it, mutating the parent reallocates/frees that buffer, leaving the
+        descendant's cached pointer dangling. The subsequent dereference of the descendant
+        pointer is a use-after-free.
+
+        JSON.SET k $ '[[0],0]' followed by JSON.ARRAPPEND k '$..' <value> crashes the server.
+
+        The fix processes matches deepest-first while writing replies back to their original
+        index.
+        '''
+        c = self.server.get_new_client()
+
+        # Each case starts from the document [[0],0].
+        # Format is (command, key, command-args, expected_reply, expected_doc_after)
+        cases = [
+            ('ARRAPPEND', 'uaf_append', ('JSON.ARRAPPEND', '$..', '"x"'),
+            [3, 2], [[0, 'x'], 0, 'x']),
+            ('ARRINSERT', 'uaf_insert', ('JSON.ARRINSERT', '$..', 0, '"x"'),
+            [3, 2], ['x', ['x', 0], 0]),
+            ('ARRPOP', 'uaf_pop', ('JSON.ARRPOP', '$..'),
+            [b'0', b'0'], [[]]),
+            ('ARRTRIM', 'uaf_trim', ('JSON.ARRTRIM', '$..', 0, 0),
+            [1, 1], [[0]]),
+            ('CLEAR', 'uaf_clear', ('JSON.CLEAR', '$..'),
+            2, []),
+        ]
+
+        for label, key, cmd, expected_reply, expected_doc in cases:
+            cmd_name = cmd[0]
+            cmd_args = cmd[1:]
+            # A document where a recursive path selects both a parent array and a
+            # descendant array nested inside it.
+            assert b'OK' == c.execute_command('JSON.SET', key, '$', '[[0],0]')
+
+            reply = c.execute_command(cmd_name, key, *cmd_args)
+
+            # The reply must be correct and in document order.
+            assert reply == expected_reply, f'JSON.{label} reply {reply!r} != {expected_reply!r}'
+
+            # The resulting document must be correct (JSON.GET $ wraps the result in an array).
+            expected_get = json.dumps([expected_doc], separators=(',', ':')).encode()
+            actual_get = c.execute_command('JSON.GET', key, '$')
+            assert actual_get == expected_get, f'JSON.{label} doc {actual_get!r} != {expected_get!r}'
+
+
 
 class TestJsonDebugGating(JsonTestCase):
     """Test that debug commands are gated behind json.debug-mode module config."""

--- a/tst/integration/test_rdb.py
+++ b/tst/integration/test_rdb.py
@@ -4,8 +4,81 @@ from valkeytests.conftest import resource_port_tracker
 import logging, os, pathlib
 import pytest
 from error_handlers import ErrorStringTester
+from valkey.exceptions import ResponseError
 
 logging.basicConfig(level=logging.DEBUG)
+
+
+# --- Helpers for crafting raw DUMP/RESTORE payloads (issue #107) ---
+
+_CRC64_POLY = 0xad93d23594c935a9
+
+
+def _reflect64(value):
+    """Reverse the bit order of a 64-bit integer."""
+    result = 0
+    for i in range(64):
+        if (value >> i) & 1:
+            result |= 1 << (63 - i)
+    return result
+
+
+def _build_crc64_table():
+    poly = _reflect64(_CRC64_POLY)
+    table = []
+    for n in range(256):
+        crc = n
+        for _ in range(8):
+            crc = (crc >> 1) ^ poly if (crc & 1) else (crc >> 1)
+        table.append(crc & 0xFFFFFFFFFFFFFFFF)
+    return table
+
+
+_CRC64_TABLE = _build_crc64_table()
+
+
+def crc64(data, crc=0):
+    """Valkey/Redis CRC-64 (Jones variant) over a byte string."""
+    for b in data:
+        crc = _CRC64_TABLE[(crc ^ b) & 0xFF] ^ (crc >> 8)
+    return crc & 0xFFFFFFFFFFFFFFFF
+
+
+def rdb_save_len(n):
+    """Encode n using Valkey's RDB length encoding."""
+    if n < (1 << 6):
+        return bytes([n])                                  # 6-bit length
+    elif n < (1 << 14):
+        return bytes([0x40 | (n >> 8), n & 0xFF])          # 14-bit length
+    elif n <= 0xFFFFFFFF:
+        return bytes([0x80]) + n.to_bytes(4, 'big')        # RDB_32BITLEN
+    else:
+        return bytes([0x81]) + n.to_bytes(8, 'big')        # RDB_64BITLEN
+
+
+# RDB_TYPE_MODULE_2 frames each saved value with a module opcode so it can be parsed
+# without the module loaded. ValkeyModule_SaveUnsigned emits: opcode + length.
+RDB_MODULE_OPCODE_EOF = 0
+RDB_MODULE_OPCODE_UINT = 2
+
+# JSON encver-0 metacodes (see meta_codes in dom.cc), each framed with OPCODE_UINT.
+JSON_METACODE_NULL = 0x01
+JSON_METACODE_STRING = 0x02
+JSON_METACODE_ARRAY = 0x40
+
+
+RDB_MODULE_OPCODE_STRING = 5
+
+
+def module_save_unsigned(n):
+    """Encode ValkeyModule_SaveUnsigned: opcode + length."""
+    return rdb_save_len(RDB_MODULE_OPCODE_UINT) + rdb_save_len(n)
+
+
+def module_save_string_buffer(data):
+    """Encode ValkeyModule_SaveStringBuffer: opcode + len + data."""
+    return rdb_save_len(RDB_MODULE_OPCODE_STRING) + rdb_save_len(len(data)) + data
+
 
 class TestRdb(JsonTestCase):
 
@@ -56,3 +129,96 @@ class TestRdb(JsonTestCase):
         assert True == client.execute_command('save')
         client.execute_command('FLUSHDB')
         assert b'OK' == client.execute_command('DEBUG', 'RELOAD', 'NOSAVE')
+
+    def test_rdb_restore_legacy_array_oom_bounded(self):
+        """
+        Regression test for issue #107: legacy RDB load passed an untrusted array count
+        directly to Reserve() and looped without IO-error checks, enabling OOM via RESTORE.
+        The fix caps pre-reservation and breaks on the first error.
+        """
+        import valkey
+        client = self.server.get_new_client()
+
+        # Self-check: CRC-64 matches the known test vector.
+        assert crc64(b"123456789") == 0xe9c6d914c4b8d9ca
+
+        # Extract module id and RDB version from a genuine DUMP.
+        assert b'OK' == client.execute_command('JSON.SET', 'arr', '.', '[1,2,3]')
+        genuine = bytes(client.execute_command('DUMP', 'arr'))
+
+        # Verify our CRC matches the server's footer.
+        assert crc64(genuine[:-8]) == int.from_bytes(genuine[-8:], 'little')
+        assert genuine[0] == 7, f"unexpected RDB type byte {genuine[0]:#x}"
+        assert genuine[1] == 0x81, f"unexpected module-id length encoding {genuine[1]:#x}"
+        module_id = int.from_bytes(genuine[2:10], 'big')
+        assert (module_id & 0x3FF) == 3, f"expected genuine encver 3, got {module_id & 0x3FF}"
+        rdbver_bytes = genuine[-10:-8]
+
+        # Downgrade encver to 0 to route through the legacy loader.
+        legacy_id_bytes = bytes([0x81]) + (module_id & ~0x3FF).to_bytes(8, 'big')
+
+        def make_restore_payload(body):
+            base = bytes([7]) + legacy_id_bytes + body + rdbver_bytes
+            return base + crc64(base).to_bytes(8, 'little')
+
+        # Positive case: a valid legacy array [null, null] must load correctly.
+        valid_body = (module_save_unsigned(JSON_METACODE_ARRAY)
+                      + module_save_unsigned(2)
+                      + module_save_unsigned(JSON_METACODE_NULL)
+                      + module_save_unsigned(JSON_METACODE_NULL)
+                      + rdb_save_len(RDB_MODULE_OPCODE_EOF))   # module value EOF marker
+        assert b'OK' == client.execute_command(
+            'RESTORE', 'legacy_ok', 0, make_restore_payload(valid_body))
+        assert b'[null,null]' == client.execute_command('JSON.GET', 'legacy_ok')
+
+        # Negative case: ~4 billion declared elements, no data. Pre-fix this OOM'd.
+        huge_body = (module_save_unsigned(JSON_METACODE_ARRAY)
+                     + module_save_unsigned((1 << 32) - 1))
+        evil_payload = make_restore_payload(huge_body)
+
+        # Short timeout as safety net if the bound regresses.
+        guarded = valkey.Valkey(host="localhost", port=self.server.port, socket_timeout=15)
+        with pytest.raises(ResponseError):
+            guarded.execute_command('RESTORE', 'evil', 0, evil_payload)
+
+        # Server must still be alive after rejecting the crafted payload.
+        assert client.execute_command('PING')
+        assert b'OK' == client.execute_command('JSON.SET', 'after', '.', '[1,2,3]')
+        assert b'[1,2,3]' == client.execute_command('JSON.GET', 'after')
+
+    def test_rdb_restore_legacy_array_truncated_element(self):
+        """
+        Safety-net: server survives a RESTORE with a truncated string element (EOF
+        mid-body). Passes on unfixed code too (core's stream-EOF catches it first),
+        but guards against regressions in that outer check.
+        """
+        import valkey
+        client = self.server.get_new_client()
+
+        # Get module id and rdbver from a genuine DUMP.
+        assert b'OK' == client.execute_command('JSON.SET', '_tmp', '.', '"x"')
+        genuine = bytes(client.execute_command('DUMP', '_tmp'))
+        client.execute_command('DEL', '_tmp')
+        module_id = int.from_bytes(genuine[2:10], 'big')
+        rdbver_bytes = genuine[-10:-8]
+        legacy_id_bytes = bytes([0x81]) + (module_id & ~0x3FF).to_bytes(8, 'big')
+
+        def make_restore_payload(body):
+            base = bytes([7]) + legacy_id_bytes + body + rdbver_bytes
+            return base + crc64(base).to_bytes(8, 'little')
+
+        # Array with a truncated string element (declares 10 bytes, provides 3).
+        truncated_body = (module_save_unsigned(JSON_METACODE_ARRAY)
+                         + module_save_unsigned(2)
+                         + module_save_unsigned(JSON_METACODE_STRING)
+                         + rdb_save_len(RDB_MODULE_OPCODE_STRING)
+                         + rdb_save_len(10)    # declares 10 bytes of string data
+                         + b'abc')             # only 3 bytes -- EOF mid-string
+
+        payload = make_restore_payload(truncated_body)
+        guarded = valkey.Valkey(host="localhost", port=self.server.port, socket_timeout=15)
+        with pytest.raises(ResponseError):
+            guarded.execute_command('RESTORE', 'trunc', 0, payload)
+
+        # Server must remain alive.
+        assert client.execute_command('PING')

--- a/tst/integration/test_rdb.py
+++ b/tst/integration/test_rdb.py
@@ -90,8 +90,8 @@ class TestRdb(JsonTestCase):
         # Otherwise, data from previous test cases will interfere current test case.
         client.execute_command("FLUSHDB")
 
-        # Load strore sample JSONs. We use strore.json as input to create a document key. Then, use
-        # strore_compact.json, which does not have indent/space/newline, to verify correctness of serialization.
+        # Load store sample JSONs. We use store.json as input to create a document key. Then, use
+        # store_compact.json, which does not have indent/space/newline, to verify correctness of serialization.
         with open(DEFAULT_STORE_PATH, 'r') as file:
             self.data_store = file.read()
         assert b'OK' == client.execute_command(

--- a/tst/unit/CMakeLists.txt
+++ b/tst/unit/CMakeLists.txt
@@ -65,7 +65,7 @@ target_link_libraries(unitTests
 # To get this to work properly in a cross-compile environment, you need to set up
 # CROSSCOMPILING_EMULATOR (see https://cmake.org/cmake/help/v3.12/prop_tgt/CROSSCOMPILING_EMULATOR.html)
 # DISCOVERY_TIMEOUT - number of seconds given for Gtest to discover the tests to run, it should
-# be big enough so the tests can start on MacOS and can be any number, 59 is just prime number
+# be big enough so the tests can start on macOS and can be any number, 59 is just prime number
 # close to 1 minute ;)
 gtest_discover_tests(unitTests
         TEST_PREFIX unit_

--- a/tst/unit/CPPLINT.cfg
+++ b/tst/unit/CPPLINT.cfg
@@ -1,4 +1,4 @@
-filter=-build/include_subdir
+filter=-build/include_subdir,-build/include_order,-build/include_what_you_use,-build/header_guard,-legal/copyright,-whitespace/newline
 # STL allocator needs implicit single arg constructor which CPPLINT doesn't like by default
 filter=-runtime/explicit
 filter=-runtime/string

--- a/tst/unit/dom_test.cc
+++ b/tst/unit/dom_test.cc
@@ -777,6 +777,44 @@ TEST_F(DomTest, testNumIncrMultBy_string_value_overflow) {
     EXPECT_FALSE(isV2Path);
 }
 
+// Numbers outside the normal double range are kept in string form, and reading them via GetDouble()
+// must not crash. std::strtod instead returns a subnormal on underflow and +/-inf on overflow, so
+// underflow goes through as normal arithmetic and overflow is caught by the existing isinf check as
+// JSONUTIL_ADDITION_OVERFLOW.
+TEST_F(DomTest, testNumIncrBy_double_out_of_range) {
+    jsn::vector<double> res;
+    bool isV2Path;
+    JParser parser;
+
+    // Case 1: Stored value is normal, the increment 1e-308 is subnormal and is converted back via
+    // GetDouble() during the addition.
+    JsonUtilCode rc = dom_set_value(nullptr, doc1, ".foo", "1.5", false, false);
+    EXPECT_EQ(rc, JSONUTIL_SUCCESS);
+    rc = dom_increment_by(doc1, ".foo", &parser.Parse("1e-308", 6).GetJValue(), res, isV2Path);
+    EXPECT_EQ(rc, JSONUTIL_SUCCESS);
+    EXPECT_EQ(res.size(), 1);
+    EXPECT_EQ(res[0], 1.5 + 1e-308);
+    EXPECT_FALSE(isV2Path);
+
+    // Case 2: subnormal stored value, the stored 1e-308 is converted back via GetDouble().
+    rc = dom_set_value(nullptr, doc1, ".foo", "1e-308", false, false);
+    EXPECT_EQ(rc, JSONUTIL_SUCCESS);
+    rc = dom_increment_by(doc1, ".foo", &parser.Parse("5", 1).GetJValue(), res, isV2Path);
+    EXPECT_EQ(rc, JSONUTIL_SUCCESS);
+    EXPECT_EQ(res.size(), 1);
+    EXPECT_EQ(res[0], 1e-308 + 5);
+    EXPECT_FALSE(isV2Path);
+
+    // Case 3: overflow stored value, a plain-digit literal >= 10^309 (> DBL_MAX) is stored in
+    // string form. GetDouble() converts it to +inf, and the addition is caught as an overflow.
+    std::string big_literal = "1" + std::string(309, '0');
+    rc = dom_set_value(nullptr, doc1, ".foo", big_literal.c_str(), false, false);
+    EXPECT_EQ(rc, JSONUTIL_SUCCESS);
+    rc = dom_increment_by(doc1, ".foo", &parser.Parse("5", 1).GetJValue(), res, isV2Path);
+    EXPECT_EQ(rc, JSONUTIL_ADDITION_OVERFLOW);
+    EXPECT_FALSE(isV2Path);
+}
+
 TEST_F(DomTest, testToggle) {
     JsonUtilCode rc = dom_set_value(nullptr, doc1, ".foobool", "true", false, false);
     EXPECT_EQ(rc, JSONUTIL_SUCCESS);

--- a/tst/unit/dom_test.cc
+++ b/tst/unit/dom_test.cc
@@ -59,7 +59,7 @@ extern size_t hash_function(const char *, size_t);
 void SetupAllocFuncs(size_t numShards) {
     setupValkeyModulePointers();
     //
-    // Now setup the KeyTable, the RapidJson library now depends on it
+    // Now set up the KeyTable, the RapidJson library now depends on it
     //
     KeyTable::Config c;
     c.malloc = dom_alloc;
@@ -869,7 +869,7 @@ TEST_F(DomTest, testToggle_v2path) {
     dom_free_doc(d1);
 }
 
-TEST_F(DomTest, testNumMutiBy_int64) {
+TEST_F(DomTest, testNumMultiBy_int64) {
     jsn::vector<double> res;
     bool isV2Path;
     JParser parser;
@@ -892,7 +892,7 @@ TEST_F(DomTest, testNumMutiBy_int64) {
     EXPECT_FALSE(isV2Path);
 }
 
-TEST_F(DomTest, testNumMutiBy_double) {
+TEST_F(DomTest, testNumMultiBy_double) {
     const char *new_val = "1";
     JsonUtilCode rc = dom_set_value(nullptr, doc1, ".foo", new_val, false, false);
     EXPECT_EQ(rc, JSONUTIL_SUCCESS);
@@ -916,7 +916,7 @@ TEST_F(DomTest, testNumMutiBy_double) {
     EXPECT_FALSE(isV2Path);
 }
 
-TEST_F(DomTest, testNumMutiBy_int64_overflow) {
+TEST_F(DomTest, testNumMultiBy_int64_overflow) {
     const char *new_val = "9223372036854775800";
     JsonUtilCode rc = dom_set_value(nullptr, doc1, ".foo", new_val, false, false);
     EXPECT_EQ(rc, JSONUTIL_SUCCESS);
@@ -945,7 +945,7 @@ TEST_F(DomTest, testNumMutiBy_int64_overflow) {
     EXPECT_FALSE(isV2Path);
 }
 
-TEST_F(DomTest, testNumMutiBy_int64_overflow_negative) {
+TEST_F(DomTest, testNumMultiBy_int64_overflow_negative) {
     const char *new_val = "-9223372036854775808";
     JsonUtilCode rc = dom_set_value(nullptr, doc1, ".foo", new_val, false, false);
     EXPECT_EQ(rc, JSONUTIL_SUCCESS);
@@ -979,7 +979,7 @@ TEST_F(DomTest, testNumMutiBy_int64_overflow_negative) {
     EXPECT_FALSE(isV2Path);
 }
 
-TEST_F(DomTest, testNumMutiBy_double_overflow) {
+TEST_F(DomTest, testNumMultiBy_double_overflow) {
     const char *new_val = "1.7e308";
     JsonUtilCode rc = dom_set_value(nullptr, doc1, ".foo", new_val, false, false);
     EXPECT_EQ(rc, JSONUTIL_SUCCESS);
@@ -1005,7 +1005,7 @@ TEST_F(DomTest, testNumMutiBy_double_overflow) {
     EXPECT_FALSE(isV2Path);
 }
 
-TEST_F(DomTest, testNumMutiBy_double_overflow_negative) {
+TEST_F(DomTest, testNumMultiBy_double_overflow_negative) {
     const char *new_val = "1.7e308";
     JsonUtilCode rc = dom_set_value(nullptr, doc1, ".foo", new_val, false, false);
     EXPECT_EQ(rc, JSONUTIL_SUCCESS);
@@ -1899,7 +1899,7 @@ TEST_F(DomTest, testSelector_get_array_legacyPath) {
     EXPECT_TRUE(selector.getResultSet().empty());
 }
 
-TEST_F(DomTest, testSelector_get_array_negativeIndex_legacy_and_v2ath) {
+TEST_F(DomTest, testSelector_get_array_negativeIndex_legacy_and_v2path) {
     const char *path = ".phoneNumbers[-1]";
     Selector selector;
     JsonUtilCode rc = selector.getValues(*doc1, path);

--- a/tst/unit/selector_test.cc
+++ b/tst/unit/selector_test.cc
@@ -1361,3 +1361,34 @@ TEST_F(SelectorTest, test_delete_insert) {
 
     dom_free_doc(d1);
 }
+
+// Deleting multiple object members whose keys contain a tilde via a multi-match path.
+TEST_F(SelectorTest, test_delete_tilde_keys) {
+    JDocument *d1;
+    const char *json = "{\"~\":1,\"~~\":2}";
+    JsonUtilCode rc = dom_parse(nullptr, json, strlen(json), &d1);
+    EXPECT_EQ(rc, JSONUTIL_SUCCESS);
+
+    size_t num_vals_deleted;
+    rc = dom_delete_value(d1, "$.*", num_vals_deleted);
+    EXPECT_EQ(rc, JSONUTIL_SUCCESS);
+    EXPECT_EQ(num_vals_deleted, 2);
+
+    dom_free_doc(d1);
+}
+
+// Recursive descent ($..*) over nested objects with tilde keys.
+TEST_F(SelectorTest, test_delete_tilde_keys_recursive) {
+    JDocument *d1;
+    const char *json = "{\"o\":{\"~\":1,\"~a\":2}}";
+    JsonUtilCode rc = dom_parse(nullptr, json, strlen(json), &d1);
+    EXPECT_EQ(rc, JSONUTIL_SUCCESS);
+
+    size_t num_vals_deleted;
+    rc = dom_delete_value(d1, "$..*", num_vals_deleted);
+    EXPECT_EQ(rc, JSONUTIL_SUCCESS);
+    EXPECT_EQ(num_vals_deleted, 3);
+
+    dom_free_doc(d1);
+}
+

--- a/tst/unit/selector_test.cc
+++ b/tst/unit/selector_test.cc
@@ -487,7 +487,7 @@ TEST_F(SelectorTest, test_filterExpr_expression_part7) {
                         "    \"poquo value\"  : \"\\\"\","
                         "    \"my key\"   : \"key inside here\""
                         "  },"
-                        "  \"anonther object\" : {"
+                        "  \"another object\" : {"
                         "    \"weight\"   : 400,"
                         "    \"a value\"  : 400,"
                         "    \"poquo value\"  : \"'\","
@@ -612,7 +612,7 @@ TEST_F(SelectorTest, test_filterExpr_single_recursion_array) {
     dom_free_doc(d1);
 }
 
-TEST_F(SelectorTest, test_filertExpr_array_index_single_recursion) {
+TEST_F(SelectorTest, test_filterExpr_array_index_single_recursion) {
     JDocument *d1;
     JsonUtilCode rc = dom_parse(nullptr, node_accounts, strlen(node_accounts), &d1);
     EXPECT_EQ(rc, JSONUTIL_SUCCESS);

--- a/tst/unit/selector_test.cc
+++ b/tst/unit/selector_test.cc
@@ -1289,6 +1289,25 @@ TEST_F(SelectorTest, test_delete) {
     dom_free_doc(d1);
 }
 
+TEST_F(SelectorTest, test_filterExpr_overflow_literal) {
+    JDocument *d1;
+    const char *input = "{\"n\":5}";
+    JsonUtilCode rc = dom_parse(nullptr, input, strlen(input), &d1);
+    EXPECT_EQ(rc, JSONUTIL_SUCCESS);
+
+    // Build the plain-digit literal 10^309, which is > DBL_MAX.
+    std::string big_literal = "1" + std::string(309, '0');
+    std::string path = "$[?(@.n > " + big_literal + ")]";
+
+    Selector selector;
+    rc = selector.getValues(*d1, path.c_str());
+    // 5 is not greater than 10^309, so no values match and it doesn't crash.
+    EXPECT_EQ(rc, JSONUTIL_SUCCESS);
+    EXPECT_EQ(selector.getResultSet().size(), 0);
+
+    dom_free_doc(d1);
+}
+
 TEST_F(SelectorTest, test_delete_insert) {
     JDocument *d1;
     const char *json = "{\"a\": { \"b\": { \"c1\": \"abc\", \"c2\": \"foo bar\", \"c3\": \"just a test\" }}}";

--- a/tst/unit/traps_test.cc
+++ b/tst/unit/traps_test.cc
@@ -34,7 +34,7 @@ extern size_t hash_function(const char *, size_t);
 static void SetupAllocFuncs(size_t numShards) {
     setupValkeyModulePointers();
     //
-    // Now setup the KeyTable, the RapidJson library now depends on it
+    // Now set up the KeyTable, the RapidJson library now depends on it
     //
     KeyTable::Config c;
     c.malloc = memory_alloc;

--- a/tst/unit/util_test.cc
+++ b/tst/unit/util_test.cc
@@ -58,8 +58,8 @@ TEST_F(UtilTest, testIsInt64) {
     EXPECT_TRUE(jsonutil_is_int64(INT16_MIN));
     EXPECT_TRUE(jsonutil_is_int64(INT32_MAX));
     EXPECT_TRUE(jsonutil_is_int64(INT32_MIN));
-    EXPECT_TRUE(jsonutil_is_int64(INT64_MAX >> 1));
-    EXPECT_TRUE(jsonutil_is_int64(8223372036854775807LL));
+    EXPECT_TRUE(jsonutil_is_int64(static_cast<double>(INT64_MAX >> 1)));
+    EXPECT_TRUE(jsonutil_is_int64(static_cast<double>(8223372036854775807LL)));
     EXPECT_TRUE(jsonutil_is_int64(INT64_MIN));
     EXPECT_FALSE(jsonutil_is_int64(1e28));      // out of range of int64
     EXPECT_FALSE(jsonutil_is_int64(1.7e308));   // out of range of int64


### PR DESCRIPTION
## Summary

Preparing 1.0 branch for 1.0.3 patch release 

### Bug fixes

- Fix crash when converting a stored number that is out of range for a double (#109)
- Fix out-of-bounds read when a member name contains `~` (#108)
- Fix crash in `JSON.MSET` when the same key is given more than once (#112)
- Bound array pre-allocation on legacy RDB and `RESTORE` load, and reject truncated streams (#111)
- Fix heap use-after-free in `JSON.MSET` caused by unclosed key handles (#116)
- Restrict `JSON.DEBUG KEYTABLE-CORRUPT`, `KEYTABLE-CLEAR` and `KEYTABLE-DISTRIBUTION` to modules loaded with `json.debug-mode` (#98)
- Set `VALKEYMODULE_OPTIONS_HANDLE_REPL_ASYNC_LOAD` to handle asynchronous replication load (#89)
- Fix build failure on GCC 16 for a `maybe_unused` variable (#97)

Release notes mark this **Upgrade urgency HIGH**, since #111 and #116 are
memory-safety issues affecting a subset of users.

### Build, test and CI

Also backported, so the branch can actually be built and tested the same way
`unstable` is.
- Upgrade pytest and add setuptools to fix the test suite (#88)
- Cast int64 literals to double in `jsonutil_is_int64` tests (#99)
- Add cpplint workflow to run the linter on PRs (#100)
- Support running integration tests against an external Valkey server (#102)
- Support reusing an externally built valkey-server and valkeymodule.h (#103)
- Make ASAN failures fail the CI workflows (#115)
- Run unstable and latest only on PRs, add a daily job for all versions (#117)
- Correct spelling and terminology across documentation and tests (#65)
- Fix typo in `tst/integration/README.md` (#90)