### PR TITLE
ci: run the full server matrix on release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,18 @@ jobs:
             | grep -E '^[0-9]+\.[0-9]+$' \
             | awk -F. -v M="$MIN_SERVER_MAJOR" '$1>=M' \
             | sort -V)
-          # PRs/pushes: fast signal — only "unstable" + the latest official release.
-          # schedule/workflow_dispatch: full supported matrix for backwards-compat.
-          if [ "$GITHUB_EVENT_NAME" = "schedule" ] || [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
-            selected="$branches"
-          else
-            selected=$(printf '%s\n' $branches | tail -n 1)
-          fi
+          target="${GITHUB_BASE_REF:-$GITHUB_REF_NAME}"
+          case "$GITHUB_EVENT_NAME" in
+            schedule|workflow_dispatch) selected="$branches" ;;
+            *)
+              if [ "$target" = "unstable" ]; then
+                selected=$(printf '%s\n' $branches | tail -n 1)
+              else
+                selected="$branches"
+              fi
+              ;;
+          esac
+          echo "valkey-json branch under test: $target"
           json=$(printf '%s\n' unstable $selected | jq -R . | jq -sc .)
           echo "Event: $GITHUB_EVENT_NAME -> versions: $json"
           echo "versions=$json" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

Since #117 the server version matrix is derived entirely from the valkey remote
branch list: `unstable` is hardcoded and the release version is `tail -n 1` of
the discovered branches. The `get-versions` job never looks at which
valkey-json branch is under test, so every pull request gets the same two
versions no matter what it targets.

On a pull request into the `1.0` branch that resolves to:

```
Event: pull_request -> versions: ["unstable","9.1"]
```

The `1.0` branch declares `['unstable', '8.0', '8.1', '9.0']`, so a change
being prepared for a 1.0 patch release is validated against a server line that
release does not target, and never against the three it does.

The daily full-matrix job added in #117 does not cover for this, because
GitHub only fires `schedule` on the default branch. Release branches lost
matrix coverage with nothing replacing it.

## Change

Pick the matrix from the valkey-json branch under test, which is
`GITHUB_BASE_REF` for a pull request and `GITHUB_REF_NAME` for a push:

- targeting `unstable` — keep the fast signal from #117, `unstable` plus the
  latest release branch
- targeting a release branch — run the full supported matrix, which is the
  coverage a patch release needs before it ships
- `schedule` / `workflow_dispatch` — full matrix, unchanged

Versions are still discovered from the valkey remote, so nothing has to be
hand-maintained when a new release branch is cut.

## Testing

Selection logic exercised for every event and branch combination:

| event | target branch | matrix |
|---|---|---|
| `pull_request` | `unstable` | `unstable, 9.1` |
| `pull_request` | `1.0` | `unstable, 8.0, 8.1, 9.0, 9.1` |
| `push` | `unstable` | `unstable, 9.1` |
| `push` | `1.0` | `unstable, 8.0, 8.1, 9.0, 9.1` |
| `schedule` | `unstable` | `unstable, 8.0, 8.1, 9.0, 9.1` |
| `workflow_dispatch` | `1.0` | `unstable, 8.0, 8.1, 9.0, 9.1` |

CI on this pull request targets `unstable`, so it should report
`unstable, 9.1` and the `get-versions` log should show the branch under test.
