### PR TITLE
Fixing crash on recursive path mutation

### DIFF
--- a/src/json/dom.cc
+++ b/src/json/dom.cc
@@ -8,6 +8,7 @@
 #include <iomanip>
 #include <cmath>
 #include <string>
+#include <algorithm>
 #include "json/rapidjson_includes.h"
 #include <rapidjson/pointer.h>
 
@@ -39,6 +40,28 @@
 
 // the one true allocator
 RapidJsonAllocator allocator;
+
+ /**
+ * Order a unique result set deepest first, using most '/' separators.
+ * Ties retain original relative order via stable sort.
+ *
+ * A size changing mutation on an array invalidates cached JValue*
+ * pointers to its elements. Acting on descendants before ancestors ensures
+ * every pointer is still valid when dereferenced as a parent's buffer is never
+ * reallocated before its children are consumed.
+ *
+ * For result sets with no parent descendant overlap, this is a stable no-op.
+ */
+STATIC jsn::vector<size_t> order_result_set_deepest_first(const jsn::vector<Selector::ValueInfo> &rs) {
+    jsn::vector<size_t> order(rs.size());
+    for (size_t i = 0; i < rs.size(); i++) order[i] = i;
+    std::stable_sort(order.begin(), order.end(), [&rs](size_t a, size_t b) {
+        size_t depth_a = std::count(rs[a].second.begin(), rs[a].second.end(), '/');
+        size_t depth_b = std::count(rs[b].second.begin(), rs[b].second.end(), '/');
+        return depth_a > depth_b;  // deeper paths first
+    });
+    return order;
+}
 
 /**
  * We want to avoid all redundant creations of an allocator -- for performance reasons.
@@ -941,7 +964,11 @@ JsonUtilCode dom_array_append(ValkeyModuleCtx *ctx, JDocument *doc, const char *
     }
     CHECK_DOCUMENT_SIZE_LIMIT(ctx, doc->size, totalJValueSize)
 
-    for (auto &v : selector.getUniqueResultSet()) {
+    auto &rs = selector.getUniqueResultSet();
+    vec.resize(rs.size());
+    // Process matches deepest first. Results are written back to their original index.
+    for (size_t idx : order_result_set_deepest_first(rs)) {
+        auto &v = rs[idx];
         if (v.first->IsArray()) {
             for (size_t i=0; i < num_values; i++) {
                 // Need to make a copy of the value because after the first call of JValue::PushBack,
@@ -949,15 +976,15 @@ JsonUtilCode dom_array_append(ValkeyModuleCtx *ctx, JDocument *doc, const char *
                 JValue copy(appendVals[i], allocator);
                 v.first->PushBack(copy, allocator);
             }
-            vec.push_back(v.first->Size());
+            vec[idx] = v.first->Size();
         } else {
-            vec.push_back(SIZE_MAX);  // indicates non-array value
+            vec[idx] = SIZE_MAX;  // indicates non-array value
         }
     }
     return JSONUTIL_SUCCESS;
 }
 
-STATIC void internal_array_pop(JValue &arrVal, int64_t index, jsn::vector<rapidjson::StringBuffer> &vec,
+STATIC void internal_array_pop(JValue &arrVal, int64_t index, rapidjson::StringBuffer &out,
                                rapidjson::StringBuffer &oss) {
     // Convert negative index to positive
     int64_t size = arrVal.Size();
@@ -969,7 +996,7 @@ STATIC void internal_array_pop(JValue &arrVal, int64_t index, jsn::vector<rapidj
 
     serialize_value(arrVal[index], 0, nullptr, oss);
     arrVal.Erase(arrVal.Begin() + index);
-    vec.push_back(std::move(oss));
+    out = std::move(oss);
 }
 
 JsonUtilCode dom_array_pop(JDocument *doc, const char *path, int64_t index,
@@ -991,16 +1018,20 @@ JsonUtilCode dom_array_pop(JDocument *doc, const char *path, int64_t index,
         if (!has_array_value(values)) return JSONUTIL_JSON_ELEMENT_NOT_ARRAY;
     }
 
-    for (auto &v : selector.getUniqueResultSet()) {
+    auto &rs = selector.getUniqueResultSet();
+    vec.resize(rs.size());
+    // Process matches deepest first. Results are written back to their original index.
+    for (size_t idx : order_result_set_deepest_first(rs)) {
+        auto &v = rs[idx];
         rapidjson::StringBuffer oss;
         if (v.first->IsArray()) {
             if (v.first->Empty()) {
-                vec.push_back(std::move(oss));  // empty array, oss is empty
+                vec[idx] = std::move(oss);  // empty array, oss is empty
             } else {
-                internal_array_pop(*v.first, index, vec, oss);
+                internal_array_pop(*v.first, index, vec[idx], oss);
             }
         } else {
-            vec.push_back(std::move(oss));  // non-array value, oss is empty
+            vec[idx] = std::move(oss);  // non-array value, oss is empty
         }
     }
 
@@ -1008,7 +1039,7 @@ JsonUtilCode dom_array_pop(JDocument *doc, const char *path, int64_t index,
 }
 
 STATIC JsonUtilCode internal_array_insert(JValue &arrVal, jsn::vector<JParser> &insertVals,
-                                          const size_t num_values, int64_t index, jsn::vector<size_t> &vec) {
+                                          const size_t num_values, int64_t index, size_t &out) {
     size_t size = arrVal.Size();
 
     // Negative index values are interpreted as starting from the end.
@@ -1038,7 +1069,7 @@ STATIC JsonUtilCode internal_array_insert(JValue &arrVal, jsn::vector<JParser> &
         arrVal[i] = copy;
     }
 
-    vec.push_back(arrVal.Size());
+    out = arrVal.Size();
     return JSONUTIL_SUCCESS;
 }
 
@@ -1074,21 +1105,25 @@ JsonUtilCode dom_array_insert(ValkeyModuleCtx *ctx, JDocument *doc, const char *
     }
     CHECK_DOCUMENT_SIZE_LIMIT(ctx, doc->size, totalJValueSize)
 
-    for (auto &v : selector.getUniqueResultSet()) {
+    auto &rs = selector.getUniqueResultSet();
+    vec.resize(rs.size());
+    // Process matches deepest first. Results are written back to their original index.
+    for (size_t idx : order_result_set_deepest_first(rs)) {
+        auto &v = rs[idx];
         if (v.first->IsArray()) {
-            rc = internal_array_insert(*v.first, insertVals, num_values, index, vec);
+            rc = internal_array_insert(*v.first, insertVals, num_values, index, vec[idx]);
             if (rc != JSONUTIL_SUCCESS) return rc;
         } else {
-            vec.push_back(SIZE_MAX);  // indicates non-array value
+            vec[idx] = SIZE_MAX;  // indicates non-array value
         }
     }
     return JSONUTIL_SUCCESS;
 }
 
-STATIC void internal_array_trim(JValue &arrVal, int64_t start, int64_t stop, jsn::vector<size_t> &vec) {
+STATIC void internal_array_trim(JValue &arrVal, int64_t start, int64_t stop, size_t &out) {
     int64_t size = static_cast<int64_t>(arrVal.Size());
     if (size == 0) {
-        vec.push_back(0);
+        out = 0;
         return;
     }
 
@@ -1101,7 +1136,7 @@ STATIC void internal_array_trim(JValue &arrVal, int64_t start, int64_t stop, jsn
     if (start >= size || start > stop) {
         // If start >= size or start > stop, empty the array and return *new_len as 0.
         arrVal.Erase(arrVal.Begin(), arrVal.End());
-        vec.push_back(0);
+        out = 0;
         return;
     }
 
@@ -1110,7 +1145,7 @@ STATIC void internal_array_trim(JValue &arrVal, int64_t start, int64_t stop, jsn
     if (start > 0)
         arrVal.Erase(arrVal.Begin(), arrVal.Begin() + start);
 
-    vec.push_back(arrVal.Size());
+    out = arrVal.Size();
 }
 
 JsonUtilCode dom_array_trim(JDocument *doc, const char *path, int64_t start, int64_t stop,
@@ -1132,11 +1167,15 @@ JsonUtilCode dom_array_trim(JDocument *doc, const char *path, int64_t start, int
         if (!has_array_value(values)) return JSONUTIL_JSON_ELEMENT_NOT_ARRAY;
     }
 
-    for (auto &v : selector.getUniqueResultSet()) {
+    auto &rs = selector.getUniqueResultSet();
+    vec.resize(rs.size());
+    // Process matches deepest first. Results are written back to their original index.
+    for (size_t idx : order_result_set_deepest_first(rs)) {
+        auto &v = rs[idx];
         if (v.first->IsArray()) {
-            internal_array_trim(*v.first, start, stop, vec);
+            internal_array_trim(*v.first, start, stop, vec[idx]);
         } else {
-            vec.push_back(SIZE_MAX);  // indicates non-array value
+            vec[idx] = SIZE_MAX;  // indicates non-array value
         }
     }
     return JSONUTIL_SUCCESS;
@@ -1148,7 +1187,10 @@ JsonUtilCode dom_clear(JDocument *doc, const char *path, size_t &elements_cleare
     JsonUtilCode rc = selector.getValues(doc->GetJValue(), path);
     if (rc != JSONUTIL_SUCCESS) return rc;
 
-    for (auto &v : selector.getUniqueResultSet()) {
+    auto &rs = selector.getUniqueResultSet();
+    // Process matches deepest-first. The reply is just a count, so order is irrelevant.
+    for (size_t idx : order_result_set_deepest_first(rs)) {
+        auto &v = rs[idx];
         if (v.first->IsArray()) {
             if (!v.first->Empty()) {
                 v.first->Erase(v.first->Begin(), v.first->End());

--- a/tst/integration/test_json_basic.py
+++ b/tst/integration/test_json_basic.py
@@ -4998,6 +4998,56 @@ class TestJsonBasic(JsonTestCase):
             print("For Path:", path, " json.get:", g, " shared-api:", s)
             assert (g == s)
 
+    def test_recursive_path_mutation_use_after_free(self):
+        '''
+        Regression test for a use-after-free crash in size-changing array/clear mutators.
+
+        Root cause: a node's JValue* points into its parent array's element buffer. When a
+        recursive path (e.g. $.. or $[*]) selects both a parent array and a descendant that
+        lives inside it, mutating the parent reallocates/frees that buffer, leaving the
+        descendant's cached pointer dangling. The subsequent dereference of the descendant
+        pointer is a use-after-free.
+
+        JSON.SET k $ '[[0],0]' followed by JSON.ARRAPPEND k '$..' <value> crashes the server.
+
+        The fix processes matches deepest-first while writing replies back to their original
+        index.
+        '''
+        c = self.server.get_new_client()
+
+        # Each case starts from the document [[0],0].
+        # Format is (command, key, command-args, expected_reply, expected_doc_after)
+        cases = [
+            ('ARRAPPEND', 'uaf_append', ('JSON.ARRAPPEND', '$..', '"x"'),
+            [3, 2], [[0, 'x'], 0, 'x']),
+            ('ARRINSERT', 'uaf_insert', ('JSON.ARRINSERT', '$..', 0, '"x"'),
+            [3, 2], ['x', ['x', 0], 0]),
+            ('ARRPOP', 'uaf_pop', ('JSON.ARRPOP', '$..'),
+            [b'0', b'0'], [[]]),
+            ('ARRTRIM', 'uaf_trim', ('JSON.ARRTRIM', '$..', 0, 0),
+            [1, 1], [[0]]),
+            ('CLEAR', 'uaf_clear', ('JSON.CLEAR', '$..'),
+            2, []),
+        ]
+
+        for label, key, cmd, expected_reply, expected_doc in cases:
+            cmd_name = cmd[0]
+            cmd_args = cmd[1:]
+            # A document where a recursive path selects both a parent array and a
+            # descendant array nested inside it.
+            assert b'OK' == c.execute_command('JSON.SET', key, '$', '[[0],0]')
+
+            reply = c.execute_command(cmd_name, key, *cmd_args)
+
+            # The reply must be correct and in document order.
+            assert reply == expected_reply, f'JSON.{label} reply {reply!r} != {expected_reply!r}'
+
+            # The resulting document must be correct (JSON.GET $ wraps the result in an array).
+            expected_get = json.dumps([expected_doc], separators=(',', ':')).encode()
+            actual_get = c.execute_command('JSON.GET', key, '$')
+            assert actual_get == expected_get, f'JSON.{label} doc {actual_get!r} != {expected_get!r}'
+
+
 
 class TestJsonDebugGating(JsonTestCase):
     """Test that debug commands are gated behind json.debug-mode module config."""


### PR DESCRIPTION
## Summary

Fixes a use-after-free crash when a recursive JSONPath expression selects both a
parent array and a descendant nested inside it, during a size-changing mutation.
Affects `JSON.ARRAPPEND`, `JSON.ARRINSERT`, `JSON.ARRPOP`, `JSON.ARRTRIM` and
`JSON.CLEAR`.

A node's `JValue*` points into its parent array's element buffer. When the parent
is mutated, that buffer is reallocated or freed, leaving the descendant's cached
pointer dangling; dereferencing it is a use-after-free.

## Fix

- Add `order_result_set_deepest_first()`, which stable-sorts matches by path depth
  so descendants are processed before their ancestors. A parent's buffer is never
  reallocated before its children have been consumed.
- Refactor the four array mutators to write results by index into a pre-sized
  vector, so replies stay in document order while processing runs depth-first.
  `internal_array_pop`, `internal_array_insert` and `internal_array_trim` now take
  a single out-parameter instead of appending to the result vector.
- `dom_clear` only returns a count, so ordering there is irrelevant.

For result sets with no parent/descendant overlap the sort is a stable no-op, so
existing behaviour and reply ordering are unchanged.
