### PR TITLE
Fix JSONPath filters over object children

### DIFF
--- a/src/json/selector.cc
+++ b/src/json/selector.cc
@@ -1125,7 +1125,7 @@ JsonUtilCode Selector::parseWildcardInBrackets() {
         if (!lex.matchToken(Token::QUESTION_MARK)) return JSONUTIL_INVALID_JSON_PATH;
         if (!lex.matchToken(Token::LPAREN)) return JSONUTIL_INVALID_JSON_PATH;
 
-        jsn::vector<int64_t> result;  // subset of indexes of the current array
+        jsn::vector<int64_t> result;  // candidate indexes/ordinals for the current container
         JsonUtilCode rc = parseFilterExpr(result);
         if (rc != JSONUTIL_SUCCESS) return rc;
 
@@ -1678,7 +1678,7 @@ JsonUtilCode Selector::processSlice(int64_t start, int64_t end, const int64_t st
 JsonUtilCode Selector::parseFilter() {
     lex.nextToken();  // skip QUESTION_MARK
     if (!lex.matchToken(Token::LPAREN)) return JSONUTIL_INVALID_JSON_PATH;
-    jsn::vector<int64_t> result;  // subset of indexes of the current array
+    jsn::vector<int64_t> result;  // candidate indexes/ordinals for the current container
     JsonUtilCode rc = parseFilterExpr(result);
     if (rc != JSONUTIL_SUCCESS) return rc;
     if (!lex.matchToken(Token::RPAREN)) return JSONUTIL_INVALID_JSON_PATH;
@@ -1701,10 +1701,23 @@ JsonUtilCode Selector::processFilterResult(jsn::vector<int64_t> &result) {
         node = nullptr;
         return JSONUTIL_SUCCESS;
     } else if (node->IsObject()) {
-        if (result.empty()) {
-            // Null out the current node to signal the node is not selected.
-            node = nullptr;
+        std::sort(result.begin(), result.end());
+        auto match = result.begin();
+        int64_t ordinal = 0;
+        for (auto &member : node->GetObject()) {
+            if (match == result.end())
+                break;
+            if (*match == ordinal) {
+                StringViewHelper member_name;
+                member_name.setInternalView(member.name.GetStringView());
+                rc = evalObjectMember(member_name, member.value);
+                if (isSyntaxError(rc)) return rc;
+                ++match;
+            }
+            ++ordinal;
         }
+
+        node = nullptr;
         return JSONUTIL_SUCCESS;
     } else {
         if (!result.empty()) {
@@ -2074,7 +2087,25 @@ JsonUtilCode Selector::processArrayContains(const StringViewHelper &member_name,
                 }
             }
         }
+    } else if (node->IsObject()) {
+        int64_t ordinal = 0;
+        for (const auto &member : node->GetObject()) {
+            const JValue &candidate = member.value;
+            if (candidate.IsObject()) {
+                auto it = candidate.FindMember(member_name.getView());
+                if (it != candidate.MemberEnd() && it->value.IsArray()) {
+                    for (const auto &element : it->value.GetArray()) {
+                        if (evalOp(&element, op, comparison_value)) {
+                            result.push_back(ordinal);
+                            break;
+                        }
+                    }
+                }
+            }
+            ++ordinal;
+        }
     }
+
     if (!lex.matchToken(Token::RPAREN, true)) return JSONUTIL_INVALID_JSON_PATH;
     if (!lex.matchToken(Token::RBRACKET)) return JSONUTIL_INVALID_JSON_PATH;
     return JSONUTIL_SUCCESS;
@@ -2106,6 +2137,25 @@ JsonUtilCode Selector::processComparisonExprAtIndex(const int64_t idx, const Str
                 }
             }
         }
+    } else if (node->IsObject()) {
+        int64_t ordinal = 0;
+        for (const auto &member : node->GetObject()) {
+            const JValue &candidate = member.value;
+            if (candidate.IsObject()) {
+                auto it = candidate.FindMember(member_name.getView());
+                if (it != candidate.MemberEnd() && it->value.IsArray()) {
+                    int64_t inner_index = idx;
+                    if (inner_index < 0) inner_index += static_cast<int64_t>(it->value.Size());
+                    if (inner_index >= 0 &&
+                        inner_index < static_cast<int64_t>(it->value.Size())) {
+                        const JValue &element = it->value.GetArray()[inner_index];
+                        if (evalOp(&element, op, comparison_value))
+                            result.push_back(ordinal);
+                    }
+                }
+            }
+            ++ordinal;
+        }
     }
     return JSONUTIL_SUCCESS;
 }
@@ -2128,12 +2178,29 @@ JsonUtilCode Selector::processComparisonExpr(const bool is_self, const StringVie
             }
             if (evalOp(v, op, comparison_value)) result.push_back(i);
         }
-    } else if (node->IsObject()){
-        JValue::MemberIterator it = node->FindMember(member_name.getView());
-        if (it != node->MemberEnd()) {
-            if (evalOp(&it->value, op, comparison_value)) result.push_back(0);
+    } else if (node->IsObject()) {
+        int64_t ordinal = 0;
+        for (const auto &member : node->GetObject()) {
+            const JValue &candidate = member.value;
+            const JValue *value = &candidate;
+            if (!is_self) {
+                if (!candidate.IsObject()) {
+                    ++ordinal;
+                    continue;
+                }
+
+                auto it = candidate.FindMember(member_name.getView());
+                if (it == candidate.MemberEnd()) {
+                    ++ordinal;
+                    continue;
+                }
+                value = &it->value;
+            }
+            if (evalOp(value, op, comparison_value))
+                result.push_back(ordinal);
+            ++ordinal;
         }
-    } else if (is_self)  {
+    } else if (is_self) {
         if (evalOp(node, op, comparison_value)) result.push_back(0);
     }
     return JSONUTIL_SUCCESS;
@@ -2316,8 +2383,15 @@ JsonUtilCode Selector::processAttributeFilter(const StringViewHelper &member_nam
             result.push_back(i);
         }
     } else if (node->IsObject()) {
-        if (node->FindMember(member_name.getView()) != node->MemberEnd())
-            result.push_back(0);
+        int64_t ordinal = 0;
+        for (const auto &member : node->GetObject()) {
+            const JValue &candidate = member.value;
+            if (candidate.IsObject() &&
+                candidate.FindMember(member_name.getView()) !=
+                    candidate.MemberEnd())
+                result.push_back(ordinal);
+            ++ordinal;
+        }
     } else {
         return JSONUTIL_INVALID_JSON_PATH;
     }
@@ -2344,7 +2418,7 @@ void Selector::vectorUnion(const jsn::vector<int64_t> &v, jsn::vector<int64_t> &
  */
 void Selector::vectorIntersection(const jsn::vector<int64_t> &v1, const jsn::vector<int64_t> &v2,
                                   jsn::vector<int64_t> &r) {
-    jsn::unordered_set<int> set(v2.begin(), v2.end());
+    jsn::unordered_set<int64_t> set(v2.begin(), v2.end());
     for (auto e : v1) {
         if (set.find(e) != set.end()) {
             r.push_back(e);

--- a/tst/integration/test_json_basic.py
+++ b/tst/integration/test_json_basic.py
@@ -139,6 +139,32 @@ arr = 'arr'
 foo = 'foo'
 baz = 'baz'
 
+OBJECT_FILTER_PRODUCTS = {
+    "productsById": {
+        "product1": {
+            "price": 10,
+            "active": True,
+            "title": "One",
+            "tags": [1, 2, 3],
+            "meta": {"old": 1},
+        },
+        "product2": {
+            "price": 20,
+            "active": False,
+            "title": "Two",
+            "tags": [4, 5, 6],
+            "meta": {"old": 2},
+        },
+        "product3": {
+            "price": 30,
+            "active": True,
+            "title": "Three",
+            "tags": [7, 8, 9],
+            "meta": {"old": 3},
+        },
+    }
+}
+
 
 # Base Test class containing all core json module tests
 class TestJsonBasic(JsonTestCase):
@@ -3350,6 +3376,335 @@ class TestJsonBasic(JsonTestCase):
                 JSON_INFO_NAMES['total_memory_bytes']]
             assert b2 == b0
 
+    @pytest.mark.parametrize(
+        "document,path,expected",
+        [
+            (
+                {"a": 1, "b": {"a": 1, "x": 2}, "c": {"a": 2}},
+                "$[?(@.a==1)]",
+                [{"a": 1, "x": 2}],
+            ),
+            (
+                OBJECT_FILTER_PRODUCTS,
+                "$.productsById[?(@.title)].title",
+                ["One", "Two", "Three"],
+            ),
+            (
+                OBJECT_FILTER_PRODUCTS,
+                "$.productsById[?(@.price > 15 && @.price < 25)].title",
+                ["Two"],
+            ),
+            (
+                OBJECT_FILTER_PRODUCTS,
+                '$.productsById[?(@.price > 25 || @.title == "One")].title',
+                ["One", "Three"],
+            ),
+            (
+                OBJECT_FILTER_PRODUCTS,
+                "$.productsById[?(@.tags[0] > 3)].title",
+                ["Two", "Three"],
+            ),
+            (
+                OBJECT_FILTER_PRODUCTS,
+                "$.productsById[?(@.tags[?(@==5)])].title",
+                ["Two"],
+            ),
+            (
+                {"low": 1, "high": 3},
+                "$[?(@ > 2)]",
+                [3],
+            ),
+            (
+                {"a value": {"weight": 300}, "weight": 300},
+                "$[?(@.weight > 200)]",
+                [{"weight": 300}],
+            ),
+            (
+                OBJECT_FILTER_PRODUCTS,
+                '$["productsById"][?(@["price"] > 20)]["title"]',
+                ["Three"],
+            ),
+            (
+                OBJECT_FILTER_PRODUCTS,
+                "$.productsById[?(@.price > 100)].title",
+                [],
+            ),
+        ],
+        ids=[
+            "object-children-not-container",
+            "attribute-existence",
+            "intersection",
+            "union-source-order",
+            "array-index",
+            "nested-filter",
+            "scalar-children",
+            "mixed-children",
+            "bracket-notation",
+            "no-match",
+        ],
+    )
+    def test_jsonpath_filter_object_children(self, document, path, expected):
+        client = self.server.get_new_client()
+        assert b'OK' == client.execute_command(
+            'JSON.SET', k1, '$', json.dumps(document))
+
+        actual = json.loads(client.execute_command('JSON.GET', k1, path))
+        assert expected == actual
+
+    @pytest.mark.parametrize(
+        "command,args,expected",
+        [
+            (
+                "JSON.GET",
+                ("$.productsById[?(@.price > 15)]",),
+                [
+                    OBJECT_FILTER_PRODUCTS["productsById"]["product2"],
+                    OBJECT_FILTER_PRODUCTS["productsById"]["product3"],
+                ],
+            ),
+            (
+                "JSON.OBJLEN",
+                ("$.productsById[?(@.price > 15)]",),
+                [5, 5],
+            ),
+            (
+                "JSON.OBJKEYS",
+                ("$.productsById[?(@.price > 15)]",),
+                [
+                    [b"price", b"active", b"title", b"tags", b"meta"],
+                    [b"price", b"active", b"title", b"tags", b"meta"],
+                ],
+            ),
+            (
+                "JSON.TYPE",
+                ("$.productsById[?(@.price > 15)]",),
+                [b"object", b"object"],
+            ),
+            (
+                "JSON.STRLEN",
+                ("$.productsById[?(@.price > 15)].title",),
+                [3, 5],
+            ),
+            (
+                "JSON.ARRLEN",
+                ("$.productsById[?(@.price > 15)].tags",),
+                [3, 3],
+            ),
+            (
+                "JSON.ARRINDEX",
+                ("$.productsById[?(@.price > 15)].tags", "5"),
+                [1, -1],
+            ),
+        ],
+    )
+    def test_jsonpath_filter_object_children_read_commands(
+            self, command, args, expected):
+        client = self.server.get_new_client()
+        assert b'OK' == client.execute_command(
+            'JSON.SET', k1, '$', json.dumps(OBJECT_FILTER_PRODUCTS))
+
+        actual = client.execute_command(command, k1, *args)
+        if command == "JSON.GET":
+            actual = json.loads(actual)
+        assert expected == actual
+
+    @pytest.mark.parametrize(
+        "command,args,expected_response,response_is_json,expected_document",
+        [
+            (
+                "JSON.GET",
+                ("$[?(@.a==1)]",),
+                [{"a": 1, "x": 2}],
+                True,
+                {"a": 1, "b": {"a": 1, "x": 2}, "c": {"a": 2}},
+            ),
+            (
+                "JSON.OBJLEN",
+                ("$[?(@.a==1)]",),
+                [2],
+                False,
+                {"a": 1, "b": {"a": 1, "x": 2}, "c": {"a": 2}},
+            ),
+            (
+                "JSON.SET",
+                ("$[?(@.a==1)].a", "9"),
+                b"OK",
+                False,
+                {"a": 1, "b": {"a": 9, "x": 2}, "c": {"a": 2}},
+            ),
+            (
+                "JSON.NUMINCRBY",
+                ("$[?(@.a==1)].a", "10"),
+                [11],
+                True,
+                {"a": 1, "b": {"a": 11, "x": 2}, "c": {"a": 2}},
+            ),
+            (
+                "JSON.DEL",
+                ("$[?(@.a==1)]",),
+                1,
+                False,
+                {"a": 1, "c": {"a": 2}},
+            ),
+            (
+                "JSON.CLEAR",
+                ("$[?(@.a==1)]",),
+                1,
+                False,
+                {"a": 1, "b": {}, "c": {"a": 2}},
+            ),
+        ],
+    )
+    def test_jsonpath_filter_object_children_command_impact(
+            self, command, args, expected_response, response_is_json,
+            expected_document):
+        client = self.server.get_new_client()
+        document = {"a": 1, "b": {"a": 1, "x": 2}, "c": {"a": 2}}
+        assert b'OK' == client.execute_command(
+            'JSON.SET', k1, '$', json.dumps(document))
+
+        actual_response = client.execute_command(command, k1, *args)
+        if response_is_json:
+            actual_response = json.loads(actual_response)
+        assert expected_response == actual_response
+        assert expected_document == json.loads(
+            client.execute_command('JSON.GET', k1))
+
+    def test_jsondel_filter_on_object_issue_79(self):
+        client = self.server.get_new_client()
+        document = {
+            "root": {
+                str(index): {"value": index}
+                for index in range(1, 6)
+            }
+        }
+        assert b'OK' == client.execute_command(
+            'JSON.SET', k1, '$', json.dumps(document))
+
+        assert 3 == client.execute_command(
+            'JSON.DEL', k1, '$.root[?(@.value > 2)]')
+        assert {"root": {
+            "1": {"value": 1},
+            "2": {"value": 2},
+        }} == json.loads(client.execute_command('JSON.GET', k1))
+
+    @pytest.mark.parametrize(
+        "member_name",
+        ["slash/key", "tilde~key", "0", "space key"],
+    )
+    def test_jsonpath_filter_object_children_preserves_member_name(
+            self, member_name):
+        client = self.server.get_new_client()
+        document = {
+            "items": {
+                member_name: {"selected": True, "value": 1},
+                "other": {"selected": False, "value": 2},
+            }
+        }
+        assert b'OK' == client.execute_command(
+            'JSON.SET', k1, '$', json.dumps(document))
+
+        assert b'OK' == client.execute_command(
+            'JSON.SET', k1,
+            '$.items[?(@.selected==true)].value', '9')
+        document["items"][member_name]["value"] = 9
+        assert document == json.loads(client.execute_command('JSON.GET', k1))
+
+    @pytest.mark.parametrize(
+        "command,args,verification_path,expected",
+        [
+            (
+                "JSON.SET",
+                ("$.productsById[?(@.price > 15)].title", '"Updated"'),
+                "$.productsById.*.title",
+                ["One", "Updated", "Updated"],
+            ),
+            (
+                "JSON.MERGE",
+                (
+                    "$.productsById[?(@.price > 15)].meta",
+                    '{"updated":true}',
+                ),
+                "$.productsById.*.meta",
+                [
+                    {"old": 1},
+                    {"old": 2, "updated": True},
+                    {"old": 3, "updated": True},
+                ],
+            ),
+            (
+                "JSON.NUMINCRBY",
+                ("$.productsById[?(@.price > 15)].price", "1"),
+                "$.productsById.*.price",
+                [10, 21, 31],
+            ),
+            (
+                "JSON.NUMMULTBY",
+                ("$.productsById[?(@.price > 15)].price", "2"),
+                "$.productsById.*.price",
+                [10, 40, 60],
+            ),
+            (
+                "JSON.TOGGLE",
+                ("$.productsById[?(@.price > 15)].active",),
+                "$.productsById.*.active",
+                [True, True, False],
+            ),
+            (
+                "JSON.STRAPPEND",
+                ("$.productsById[?(@.price > 15)].title", '"!"'),
+                "$.productsById.*.title",
+                ["One", "Two!", "Three!"],
+            ),
+            (
+                "JSON.ARRAPPEND",
+                ("$.productsById[?(@.price > 15)].tags", "10"),
+                "$.productsById.*.tags",
+                [[1, 2, 3], [4, 5, 6, 10], [7, 8, 9, 10]],
+            ),
+            (
+                "JSON.ARRINSERT",
+                ("$.productsById[?(@.price > 15)].tags", "0", "0"),
+                "$.productsById.*.tags",
+                [[1, 2, 3], [0, 4, 5, 6], [0, 7, 8, 9]],
+            ),
+            (
+                "JSON.ARRPOP",
+                ("$.productsById[?(@.price > 15)].tags", "-1"),
+                "$.productsById.*.tags",
+                [[1, 2, 3], [4, 5], [7, 8]],
+            ),
+            (
+                "JSON.ARRTRIM",
+                ("$.productsById[?(@.price > 15)].tags", "0", "1"),
+                "$.productsById.*.tags",
+                [[1, 2, 3], [4, 5], [7, 8]],
+            ),
+            (
+                "JSON.CLEAR",
+                ("$.productsById[?(@.price > 15)].tags",),
+                "$.productsById.*.tags",
+                [[1, 2, 3], [], []],
+            ),
+            (
+                "JSON.DEL",
+                ("$.productsById[?(@.price > 15)]",),
+                "$.productsById.*.title",
+                ["One"],
+            ),
+        ],
+    )
+    def test_jsonpath_filter_object_children_mutation_commands(
+            self, command, args, verification_path, expected):
+        client = self.server.get_new_client()
+        assert b'OK' == client.execute_command(
+            'JSON.SET', k1, '$', json.dumps(OBJECT_FILTER_PRODUCTS))
+
+        client.execute_command(command, k1, *args)
+        actual = json.loads(
+            client.execute_command('JSON.GET', k1, verification_path))
+        assert expected == actual
+
     def test_jsonpath_filter_expression(self):
         client = self.server.get_new_client()
 
@@ -3498,9 +3853,9 @@ class TestJsonBasic(JsonTestCase):
             (k4, '$["books"][?((@["price"]>1&&@["price"]<20)&&(@["sold"]==false))]',
              b'[{"price":15,"sold":false,"title":"abc"}]'),
             (k5, '$.*[?(@ > 7 || @ < 3)]',
-             b'[8,9,1,2]'),   # order test
+             b'[8,9,1,2]'),   # expression-order compatibility test
             (k5, '$.*[?(@ < 3 || @ > 7)]',
-             b'[1,2,8,9]'),   # order test
+             b'[1,2,8,9]'),   # expression-order compatibility test
             (k5, '$.*[?(@ > 3 && @ < 7)]',
              b'[4,5,6]')
         ]:
@@ -4034,16 +4389,16 @@ class TestJsonBasic(JsonTestCase):
 
         for (key, path, exp) in [
             (k1, '$["an object"].[?(@.weight > 200)].["a value"]',
-             b'[300]'),
+             b'[]'),
             (k1, '$["an object"].[?(@.weight == 300)].["a value"]',
-             b'[300]'),
+             b'[]'),
             (k1, '$["an object"].[?(@.weight > 300)].["a value"]',
              b'[]'),
             (k1, '$["another object"].[?(@["a value"] > 200)].weight',
-             b'[400]'),
+             b'[]'),
             (k1, '$["another object"].[?(@.["a value"] > 200)].weight',
-             b'[400]'),
-            (k1, '$["another object"].[?(@.["my key"] == "key inside there")].weight', b'[400]'),
+             b'[]'),
+            (k1, '$["another object"].[?(@.["my key"] == "key inside there")].weight', b'[]'),
             (k1, '$["objects"].[?(@.weight > 200)].["a value"]',
              b'[300,400]'),
             (k1, '$["objects"].[?(@.["my key"] == "key inside there")].weight',

--- a/tst/unit/selector_test.cc
+++ b/tst/unit/selector_test.cc
@@ -67,6 +67,37 @@ class SelectorTest : public ::testing::Test {
                         "  }\n"
                         "}";
 
+    const char *object_store =
+        "{\n"
+        "  \"booksById\": {\n"
+        "    \"book1\": {\n"
+        "      \"bookTitle\": \"Sayings of the Century\",\n"
+        "      \"price\": 8.95,\n"
+        "      \"ratings\": [2, 4]\n"
+        "    },\n"
+        "    \"book2\": {\n"
+        "      \"bookTitle\": \"Sword of Honour\",\n"
+        "      \"price\": 12.99,\n"
+        "      \"ratings\": [3, 4]\n"
+        "    },\n"
+        "    \"book3\": {\n"
+        "      \"bookTitle\": \"Moby Dick\",\n"
+        "      \"price\": 18.99,\n"
+        "      \"ratings\": [5, 4]\n"
+        "    },\n"
+        "    \"book4\": {\n"
+        "      \"bookTitle\": \"The Lord of the Rings\",\n"
+        "      \"price\": 22.99,\n"
+        "      \"ratings\": [2, 5]\n"
+        "    },\n"
+        "    \"book5\": {\n"
+        "      \"bookTitle\": \"Ulysses\",\n"
+        "      \"price\": 30.0,\n"
+        "      \"ratings\": [1, 2]\n"
+        "    }\n"
+        "  }\n"
+        "}";
+
     const char *node_accounts = "{\n"
                                 "  \"clientName\": \"jim\",\n"
                                 "  \"nameSpace\": \"BobSpace\",\n"
@@ -119,7 +150,32 @@ class SelectorTest : public ::testing::Test {
         delete keyTable;
         keyTable = nullptr;
     }
+
+    void expectStringResults(JDocument &document, const char *path,
+                             const std::vector<const char *> &expected) {
+        SCOPED_TRACE(path);
+        Selector selector;
+        ASSERT_EQ(selector.getValues(document, path), JSONUTIL_SUCCESS);
+
+        const auto &results = selector.getResultSet();
+        ASSERT_EQ(results.size(), expected.size());
+        size_t index = 0;
+        for (const char *value : expected) {
+            EXPECT_STREQ(results[index].first->GetString(), value);
+            ++index;
+        }
+    }
 };
+
+struct ObjectFilterCase {
+    const char *name;
+    const char *path;
+    std::vector<const char *> expected;
+};
+
+class ObjectFilterTest
+    : public SelectorTest,
+      public ::testing::WithParamInterface<ObjectFilterCase> {};
 
 TEST_F(SelectorTest, test_filterExpr_attributeFilter) {
     JDocument *d1;
@@ -442,14 +498,14 @@ TEST_F(SelectorTest, test_filterExpr_expression_part6) {
     rc = selector.getValues(*d1, "$..[?(@.NumEntry>4)].NumEntry");
     EXPECT_EQ(rc, JSONUTIL_SUCCESS);
     auto &rs0 = selector.getResultSet();
-    EXPECT_EQ(rs0.size(), 2);
+    ASSERT_EQ(rs0.size(), 2);
     EXPECT_EQ(rs0[0].first->GetInt(), 5);
     EXPECT_EQ(rs0[1].first->GetInt(), 6);
 
     rc = selector.getValues(*d1, "$..[?(4<@.NumEntry||@.NumEntry<3)].NumEntry");
     EXPECT_EQ(rc, JSONUTIL_SUCCESS);
     auto &rs1 = selector.getResultSet();
-    EXPECT_EQ(rs1.size(), 4);
+    ASSERT_EQ(rs1.size(), 4);
     EXPECT_EQ(rs1[0].first->GetInt(), 5);
     EXPECT_EQ(rs1[1].first->GetInt(), 6);
     EXPECT_EQ(rs1[2].first->GetInt(), 1);
@@ -458,14 +514,14 @@ TEST_F(SelectorTest, test_filterExpr_expression_part6) {
     rc = selector.getValues(*d1, "$..NumEntry[?(@>4)]");
     EXPECT_EQ(rc, JSONUTIL_SUCCESS);
     auto &rs2 = selector.getResultSet();
-    EXPECT_EQ(rs2.size(), 2);
+    ASSERT_EQ(rs2.size(), 2);
     EXPECT_EQ(rs2[0].first->GetInt(), 5);
     EXPECT_EQ(rs2[1].first->GetInt(), 6);
 
     rc = selector.getValues(*d1, "$..[\"NumEntry\"][?(6>@&&@>3)]");
     EXPECT_EQ(rc, JSONUTIL_SUCCESS);
     auto &rs3 = selector.getResultSet();
-    EXPECT_EQ(rs3.size(), 2);
+    ASSERT_EQ(rs3.size(), 2);
     EXPECT_EQ(rs3[0].first->GetInt(), 4);
     EXPECT_EQ(rs3[1].first->GetInt(), 5);
 
@@ -1081,12 +1137,11 @@ TEST_F(SelectorTest, test_filter_on_object) {
     EXPECT_EQ(rc, JSONUTIL_SUCCESS);
 
     Selector selector;
-    rc = selector.getValues(*d1, "$.[\"an object\"].[?(@.weight > 200)].[\"a value\"]");
+    rc = selector.getValues(*d1, "$[\"an object\"].[?(@.weight > 200)].[\"a value\"]");
     EXPECT_EQ(rc, JSONUTIL_SUCCESS);
-    EXPECT_EQ(selector.getResultSet().size(), 1);
-    EXPECT_EQ(selector.getResultSet()[0].first->GetInt(), 300);
+    EXPECT_TRUE(selector.getResultSet().empty());
 
-    rc = selector.getValues(*d1, "$.[\"an object\"].[?(@.weight > 300)].[\"a value\"]");
+    rc = selector.getValues(*d1, "$[\"an object\"].[?(@.weight > 300)].[\"a value\"]");
     EXPECT_EQ(rc, JSONUTIL_SUCCESS);
     EXPECT_EQ(selector.getResultSet().size(), 0);
 
@@ -1289,6 +1344,146 @@ TEST_F(SelectorTest, test_delete) {
     dom_free_doc(d1);
 }
 
+TEST_F(SelectorTest, test_delete_filter_on_object_members) {
+    JDocument *d1;
+    JsonUtilCode rc = dom_parse(nullptr, object_store, strlen(object_store), &d1);
+    EXPECT_EQ(rc, JSONUTIL_SUCCESS);
+
+    size_t num_vals_deleted;
+    rc = dom_delete_value(d1, "$.booksById[?(@.price > 15)]",
+                          num_vals_deleted);
+    EXPECT_EQ(rc, JSONUTIL_SUCCESS);
+    EXPECT_EQ(num_vals_deleted, 3);
+
+    Selector selector;
+    rc = selector.getValues(*d1, "$.booksById.*");
+    EXPECT_EQ(rc, JSONUTIL_SUCCESS);
+    EXPECT_EQ(selector.getResultSet().size(), 2);
+
+    dom_free_doc(d1);
+}
+
+TEST_F(SelectorTest, test_read_and_update_filter_on_object_members) {
+    JDocument *d1;
+    JsonUtilCode rc = dom_parse(nullptr, object_store, strlen(object_store), &d1);
+    EXPECT_EQ(rc, JSONUTIL_SUCCESS);
+
+    Selector selector;
+    rc = selector.getValues(*d1, "$.booksById[?(@.price > 15)]");
+    EXPECT_EQ(rc, JSONUTIL_SUCCESS);
+    ASSERT_EQ(selector.getResultSet().size(), 3);
+    EXPECT_STREQ(selector.getResultSet()[0].second.c_str(), "/booksById/book3");
+    EXPECT_STREQ(selector.getResultSet()[1].second.c_str(), "/booksById/book4");
+    EXPECT_STREQ(selector.getResultSet()[2].second.c_str(), "/booksById/book5");
+
+    expectStringResults(
+        *d1, "$.booksById[?(@.price > 15)].bookTitle",
+        {"Moby Dick", "The Lord of the Rings", "Ulysses"});
+
+    rc = dom_set_value(nullptr, d1,
+                       "$.booksById[?(@.price > 15)].bookTitle",
+                       "\"Selected\"");
+    EXPECT_EQ(rc, JSONUTIL_SUCCESS);
+
+    expectStringResults(
+        *d1, "$.booksById.*.bookTitle",
+        {"Sayings of the Century", "Sword of Honour", "Selected", "Selected",
+         "Selected"});
+
+    dom_free_doc(d1);
+}
+
+TEST_P(ObjectFilterTest, returns_matching_object_members) {
+    JDocument *d1;
+    JsonUtilCode rc = dom_parse(nullptr, object_store, strlen(object_store), &d1);
+    EXPECT_EQ(rc, JSONUTIL_SUCCESS);
+
+    const ObjectFilterCase &test_case = GetParam();
+    expectStringResults(*d1, test_case.path, test_case.expected);
+
+    dom_free_doc(d1);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ObjectChildren, ObjectFilterTest,
+    ::testing::Values(
+        ObjectFilterCase{
+            "AttributeExists",
+            "$.booksById[?(@.bookTitle)].bookTitle",
+            {"Sayings of the Century", "Sword of Honour", "Moby Dick",
+             "The Lord of the Rings", "Ulysses"}},
+        ObjectFilterCase{
+            "Intersection",
+            "$.booksById[?(@.price > 15 && @.price < 25)].bookTitle",
+            {"Moby Dick", "The Lord of the Rings"}},
+        ObjectFilterCase{
+            "Union",
+            "$.booksById[?(@.price > 25 || "
+            "@.bookTitle == \"Sayings of the Century\")].bookTitle",
+            {"Sayings of the Century", "Ulysses"}},
+        ObjectFilterCase{
+            "ArrayIndex",
+            "$.booksById[?(@.ratings[0] > 2)].bookTitle",
+            {"Sword of Honour", "Moby Dick"}},
+        ObjectFilterCase{
+            "NestedFilter",
+            "$.booksById[?(@.ratings[?(@==4)])].bookTitle",
+            {"Sayings of the Century", "Sword of Honour", "Moby Dick"}},
+        ObjectFilterCase{
+            "NoMatch",
+            "$.booksById[?(@.price > 100)].bookTitle",
+            {}},
+        ObjectFilterCase{
+            "ImpossibleIntersection",
+            "$.booksById[?(@.price > 25 && @.price < 10)].bookTitle",
+            {}},
+        ObjectFilterCase{
+            "FilterOnSingleObject",
+            "$.booksById.book3[?(@.bookTitle)].bookTitle",
+            {}},
+        ObjectFilterCase{
+            "RecursiveDescent",
+            "$..[?(@.price > 15)].bookTitle",
+            {"Moby Dick", "The Lord of the Rings", "Ulysses"}}),
+    [](const ::testing::TestParamInfo<ObjectFilterCase> &info) {
+        return info.param.name;
+    });
+
+TEST_F(SelectorTest, test_filter_union_preserves_array_expression_order) {
+    const char *input =
+        "[{\"id\":\"first\",\"price\":20},"
+        "{\"id\":\"second\",\"price\":0},"
+        "{\"id\":\"third\",\"price\":30}]";
+    JDocument *d1;
+    JsonUtilCode rc = dom_parse(nullptr, input, strlen(input), &d1);
+    EXPECT_EQ(rc, JSONUTIL_SUCCESS);
+
+    Selector selector;
+    rc = selector.getValues(*d1, "$[?(@.price > 15 || @.id == \"second\")].id");
+    EXPECT_EQ(rc, JSONUTIL_SUCCESS);
+    ASSERT_EQ(selector.getResultSet().size(), 3);
+    EXPECT_STREQ(selector.getResultSet()[0].first->GetString(), "first");
+    EXPECT_STREQ(selector.getResultSet()[1].first->GetString(), "third");
+    EXPECT_STREQ(selector.getResultSet()[2].first->GetString(), "second");
+
+    dom_free_doc(d1);
+}
+
+TEST_F(SelectorTest, test_filter_object_scalar_members) {
+    const char *input = "{\"low\":1,\"high\":3}";
+    JDocument *d1;
+    JsonUtilCode rc = dom_parse(nullptr, input, strlen(input), &d1);
+    EXPECT_EQ(rc, JSONUTIL_SUCCESS);
+
+    Selector selector;
+    rc = selector.getValues(*d1, "$[?(@ > 2)]");
+    EXPECT_EQ(rc, JSONUTIL_SUCCESS);
+    ASSERT_EQ(selector.getResultSet().size(), 1);
+    EXPECT_EQ(selector.getResultSet()[0].first->GetInt(), 3);
+
+    dom_free_doc(d1);
+}
+
 TEST_F(SelectorTest, test_filterExpr_overflow_literal) {
     JDocument *d1;
     const char *input = "{\"n\":5}";
@@ -1391,4 +1586,3 @@ TEST_F(SelectorTest, test_delete_tilde_keys_recursive) {
 
     dom_free_doc(d1);
 }
-


### PR DESCRIPTION
## Summary

Make filters applied to JSON objects evaluate each object child as a candidate and preserve object-member paths when traversing selected members.

- Add object-child handling for attribute, comparison, array-index, nested, and recursive filters.
- Preserve member names for reads and mutations through filtered object paths.
- Add focused selector and integration coverage, including no-match and expression-order cases.

Fixes #79

## Tests

- build/tst/unit/unitTests (225/225 passed)